### PR TITLE
Refine a small typo in scheduler

### DIFF
--- a/nanovllm/engine/scheduler.py
+++ b/nanovllm/engine/scheduler.py
@@ -23,7 +23,7 @@ class Scheduler:
     def add(self, seq: Sequence):
         self.waiting.append(seq)
 
-    def schedule(self) -> tuple[list[Sequence], SequenceStatus]:
+    def schedule(self) -> tuple[list[Sequence], bool]:
         # prefill
         scheduled_seqs = []
         num_seqs = 0


### PR DESCRIPTION
The second return args in `def schedule(...)` is bool, which means whether the sequence is prefill