### PR TITLE
Fix multi-rank inference crash by using spawn context for process startup

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,29 +1,39 @@
 import os
 from nanovllm import LLM, SamplingParams
 from transformers import AutoTokenizer
+import torch.multiprocessing as mp
+import argparse
 
+def main(path, rank):
+    path = os.path.expanduser(path)
+    tokenizer = AutoTokenizer.from_pretrained(path)
+    llm = LLM(path, enforce_eager=True, tensor_parallel_size=rank)
 
-path = os.path.expanduser("~/huggingface/Qwen3-0.6B/")
-tokenizer = AutoTokenizer.from_pretrained(path)
-llm = LLM(path, enforce_eager=True)
+    sampling_params = SamplingParams(temperature=0.6, max_tokens=256)
+    prompts = [
+        "introduce yourself",
+        "list all prime numbers within 100",
+    ]
+    prompts = [
+        tokenizer.apply_chat_template(
+            [{"role": "user", "content": prompt}],
+            tokenize=False,
+            add_generation_prompt=True,
+            enable_thinking=True
+        )
+        for prompt in prompts
+    ]
+    outputs = llm.generate(prompts, sampling_params)
 
-sampling_params = SamplingParams(temperature=0.6, max_tokens=256)
-prompts = [
-    "introduce yourself",
-    "list all prime numbers within 100",
-]
-prompts = [
-    tokenizer.apply_chat_template(
-        [{"role": "user", "content": prompt}],
-        tokenize=False,
-        add_generation_prompt=True,
-        enable_thinking=True
-    )
-    for prompt in prompts
-]
-outputs = llm.generate(prompts, sampling_params)
-
-for prompt, output in zip(prompts, outputs):
-    print("\n")
-    print(f"Prompt: {prompt!r}")
-    print(f"Completion: {output['text']!r}")
+    for prompt, output in zip(prompts, outputs):
+        print("\n")
+        print(f"Prompt: {prompt!r}")
+        print(f"Completion: {output['text']!r}")
+    
+if __name__ == '__main__':
+    mp.set_start_method('spawn', force=True)
+    parser = argparse.ArgumentParser(description="Use 'rank' and 'path' parameters to control multi-rank inference and model path.")
+    parser.add_argument('--rank', default=1, type=int)
+    parser.add_argument('--path', default="/home/data/Qwen3-8B", type=str)
+    args = parser.parse_args()
+    main(args.path, args.rank)


### PR DESCRIPTION
Forked processes were causing CUDA initialization errors and NCCL deadlocks, making multi-rank inference fail with runtime errors (e.g. RuntimeError: Cannot re-initialize CUDA in forked subprocess,  issue #16).

This PR updates model_runner to run under the spawn start method via mp.spawn, matching behavior in vLLM and ensuring CUDA/NCCL initialization behaves correctly. This makes multi-GPU inference stable and consistent across ranks.

Running example:

```shell
python3 example.py --rank 2 --path /home/data/Qwen3-8B
```

Results

```
rank 1 waiting to start
rank 1 model loaded!
[rank1]:[W616 20:04:16.433745827 ProcessGroupNCCL.cpp:4715] [PG ID 0 PG GUID 0 Rank 1]  using GPU 1 as device used by this process is currently unknown. This can potentially cause a hang if this rank to GPU mapping is incorrect. You can pecify device_id in init_process_group() to force use of a particular device.
rank 0 model loaded!
[rank0]:[W616 20:04:16.597100281 ProcessGroupNCCL.cpp:4715] [PG ID 0 PG GUID 0 Rank 0]  using GPU 0 as device used by this process is currently unknown. This can potentially cause a hang if this rank to GPU mapping is incorrect. You can pecify device_id in init_process_group() to force use of a particular device.
all ranks loaded!
Generating: 100%|██████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:12<00:00,  6.23s/it, Prefill=15tok/s, Decode=53tok/s]


Prompt: '<|im_start|>user\nintroduce yourself<|im_end|>\n<|im_start|>assistant\n'
Completion: "<think>\nOkay, the user asked me to introduce myself. I need to provide a clear and friendly response. Let me start by mentioning my name, Qwen, and my role as a large language model. I should highlight my capabilities like answering questions, creating content, and having conversations. It's important to mention that I can assist with various tasks such as writing, coding, and problem-solving. I should also note that I'm continuously learning and improving to better serve users. Keeping the tone positive and approachable is key. Let me make sure the response is concise but covers all the main points. Oh, and maybe add a friendly closing to invite further interaction. Let me check if there's anything else the user might expect, like specific examples of my abilities. Hmm, maybe mention multilingual support and the ability to handle different topics. Alright, that should cover it.\n</think>\n\nHello! I'm Qwen, a large language model developed by Alibaba Cloud. I'm designed to assist with a wide range of tasks, including answering questions, creating content, and engaging in conversations. Whether you need help with writing, coding, problem-solving, or just want to chat, I'm here to support you! I can understand and respond in multiple languages, and I'm continuously"


Prompt: '<|im_start|>user\nlist all prime numbers within 100<|im_end|>\n<|im_start|>assistant\n'
Completion: "<think>\nOkay, so I need to list all the prime numbers within 100. Let me think about how to approach this. First, I remember that a prime number is a number greater than 1 that has no divisors other than 1 and itself. So, numbers like 2, 3, 5, 7, etc. But I need to make sure I don't include any composite numbers. Let me start by recalling the definition again to be sure.\n\nPrime numbers are numbers that can only be divided evenly by 1 and themselves. So, for example, 4 is not a prime number because it can be divided by 2. Similarly, 6 can be divided by 2 and 3. So, I need to check each number from 2 up to 100 and see if they meet the prime criteria.\n\nLet me start listing numbers from 2 upwards and check each one:\n\nStarting with 2: It's the smallest prime number. It's only divisible by 1 and 2. So, yes, prime.\n\n3: Divisible by 1 and 3. Prime.\n\n4: Divisible by 1, 2, 4. Not prime.\n\n5: Divisible by 1"
[rank0]:[W616 20:04:32.698949637 ProcessGroupNCCL.cpp:1476] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
```