### PR TITLE
Fix: Add device_ids to dist.barrier for robust GPU synchronization

### DIFF
--- a/nanovllm/engine/model_runner.py
+++ b/nanovllm/engine/model_runner.py
@@ -40,16 +40,16 @@ class ModelRunner:
         if self.world_size > 1:
             if rank == 0:
                 self.shm = SharedMemory(name="nanovllm", create=True, size=2**20)
-                dist.barrier()
+                dist.barrier(device_ids=[self.rank])
             else:
-                dist.barrier()
+                dist.barrier(device_ids=[self.rank])
                 self.shm = SharedMemory(name="nanovllm")
                 self.loop()
 
     def exit(self):
         if self.world_size > 1:
             self.shm.close()
-            dist.barrier()
+            dist.barrier(device_ids=[self.rank])
             if self.rank == 0:
                 self.shm.unlink()
         if not self.enforce_eager:


### PR DESCRIPTION
Hi, great work on this project! I'm really impressed with the clean architecture.

While running on a system with `PyTorch 2.6.0, CUDA 12.4, and 8x A100 GPUs`, I encountered the following warnings from **ProcessGroupNCCL** when running **example.py**:

```shell
root@0050e175bcca:~/nano-vllm# python example.py 
[rank7]:[W622 17:35:13.321650649 ProcessGroupNCCL.cpp:4561] [PG ID 0 PG GUID 0 Rank 7]  using GPU 7 to perform barrier as devices used by this process are currently unknown. This can potentially cause a hang if this rank to GPU mapping is incorrect. Specify device_ids in barrier() to force use of a particular device, or call init_process_group() with a device_id.
[rank2]:[W622 17:35:15.675097903 ProcessGroupNCCL.cpp:4561] [PG ID 0 PG GUID 0 Rank 2]  using GPU 2 to perform barrier as devices used by this process are currently unknown. This can potentially cause a hang if this rank to GPU mapping is incorrect. Specify device_ids in barrier() to force use of a particular device, or call init_process_group() with a device_id.
[rank6]:[W622 17:35:16.289687535 ProcessGroupNCCL.cpp:4561] [PG ID 0 PG GUID 0 Rank 6]  using GPU 6 to perform barrier as devices used by this process are currently unknown. This can potentially cause a hang if this rank to GPU mapping is incorrect. Specify device_ids in barrier() to force use of a particular device, or call init_process_group() with a device_id.
[rank0]:[W622 17:35:16.772230596 ProcessGroupNCCL.cpp:4561] [PG ID 0 PG GUID 0 Rank 0]  using GPU 0 to perform barrier as devices used by this process are currently unknown. This can potentially cause a hang if this rank to GPU mapping is incorrect. Specify device_ids in barrier() to force use of a particular device, or call init_process_group() with a device_id.
[rank1]:[W622 17:35:16.804613215 ProcessGroupNCCL.cpp:4561] [PG ID 0 PG GUID 0 Rank 1]  using GPU 1 to perform barrier as devices used by this process are currently unknown. This can potentially cause a hang if this rank to GPU mapping is incorrect. Specify device_ids in barrier() to force use of a particular device, or call init_process_group() with a device_id.
[rank4]:[W622 17:35:16.834243621 ProcessGroupNCCL.cpp:4561] [PG ID 0 PG GUID 0 Rank 4]  using GPU 4 to perform barrier as devices used by this process are currently unknown. This can potentially cause a hang if this rank to GPU mapping is incorrect. Specify device_ids in barrier() to force use of a particular device, or call init_process_group() with a device_id.
[rank5]:[W622 17:35:16.883225144 ProcessGroupNCCL.cpp:4561] [PG ID 0 PG GUID 0 Rank 5]  using GPU 5 to perform barrier as devices used by this process are currently unknown. This can potentially cause a hang if this rank to GPU mapping is incorrect. Specify device_ids in barrier() to force use of a particular device, or call init_process_group() with a device_id.
[rank3]:[W622 17:35:16.884669613 ProcessGroupNCCL.cpp:4561] [PG ID 0 PG GUID 0 Rank 3]  using GPU 3 to perform barrier as devices used by this process are currently unknown. This can potentially cause a hang if this rank to GPU mapping is incorrect. Specify device_ids in barrier() to force use of a particular device, or call init_process_group() with a device_id.
Generating: 100%|█████████████████████████████████████████████████████████████████████| 2/2 [00:29<00:00, 14.88s/it, Prefill=2tok/s, Decode=27tok/s]


Prompt: '<|im_start|>user\nintroduce yourself<|im_end|>\n<|im_start|>assistant\n'
Completion: "<think>\nOkay, the user wants me to introduce myself. Let me start by recalling my name and role. I'm an AI assistant designed to help users with various queries. I should mention my capabilities, like language understanding and problem-solving assistance. I need to keep the tone friendly and helpful. Also, I should thank the user for their question to show that I'm willing to help. Let me structure this clearly and make sure it's easy to read.\n</think>\n\nHello! I'm an AI assistant designed to help you with your questions and provide support. I can assist with a wide range of tasks, from general information to specific problems. If you have any questions, feel free to ask! 😊<|im_end|>"


Prompt: '<|im_start|>user\nlist all prime numbers within 100<|im_end|>\n<|im_start|>assistant\n'
Completion: "<think>\nOkay, so I need to list all the prime numbers within the range of 100. Let me think. First, I remember that a prime number is a number greater than 1 that has no positive divisors other than 1 and itself. So, starting from 100, maybe I should check each number and see if it's prime. But wait, 100 itself is not prime because it's even and divisible by 2, right? So 100 is out.\n\nLet me start from 100 and go down. Let's see:\n\n100: even, not prime.\n\n99: ends with 9, which is not 0 or 5. Let me check divisibility. Divided by 3? 99 divided by 3 is 33. So 99 is 3 times 33, so 99 is not prime.\n\n98: even, so no.\n\n97: Hmm, that's a prime number. Let me confirm. 97 divided by 2 is 48.5, not integer. Divided by 3? 9+7=16, not divisible by 3. Divided by"
```


As the warning correctly suggests, using a barrier without device IDs only syncs the CPU, which can lead to race conditions with asynchronous GPU operations.


This PR adds **device_ids=[self.rank]** to the **dist.barrier()** calls. After applying this change, the warnings are completely gone, and the multi-GPU logic is made more robust by ensuring full CPU/GPU synchronization.


Hope this helps!