### PR TITLE
Fix: Division-by-Zero Risk and Typo

### DIFF
--- a/nanovllm/engine/llm_engine.py
+++ b/nanovllm/engine/llm_engine.py
@@ -15,8 +15,8 @@ from nanovllm.engine.model_runner import ModelRunner
 class LLMEngine:
 
     def __init__(self, model, **kwargs):
-        config_fileds = {field.name for field in fields(Config)}
-        config_kwargs = {k: v for k, v in kwargs.items() if k in config_fileds}
+        config_fields = {field.name for field in fields(Config)}
+        config_kwargs = {k: v for k, v in kwargs.items() if k in config_fields}
         config = Config(model, **config_kwargs)
         self.ps = []
         self.events = []

--- a/nanovllm/layers/sampler.py
+++ b/nanovllm/layers/sampler.py
@@ -13,5 +13,6 @@ class Sampler(nn.Module):
         logits.div_(temperatures.unsqueeze(dim=1))
         probs = torch.softmax(logits, dim=-1, dtype=torch.float)
         # logprobs = torch.log_softmax(logits, dim=-1, dtype=torch.float)
-        sample_tokens = probs.div_(torch.empty_like(probs).exponential_(1)).argmax(dim=-1)
+        epsilon = 1e-10  
+        sample_tokens = probs.div_(torch.empty_like(probs).exponential_(1) + epsilon).argmax(dim=-1)  
         return torch.where(temperatures == 0, greedy_tokens, sample_tokens)


### PR DESCRIPTION
1. **Typo Error**  
   - The original code had a typo in `config_fileds` .  
   - After fix: `config_fields = {field.name for field in fields(Config)}`  

2. **Division-by-Zero Risk**  
   - The original code directly used exponentially distributed random numbers as denominators without handling potential zero values:  
     ```python  
     sample_tokens = probs.div_(torch.empty_like(probs).exponential_(1)).argmax(dim=-1)  
     ```  
   - When the random number generator produces a zero (especially in float16 precision), this causes division-by-zero errors or returns infinity (inf), compromising model stability.  