### PR TITLE
Docs/manual download

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,8 @@ See `bench.py` for benchmark.
 |----------------|-------------|----------|-----------------------|
 | vLLM           | 133,966     | 98.37    | 1361.84               |
 | Nano-vLLM      | 133,966     | 93.41    | 1434.13               |
+
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=GeeeekExplorer/nano-vllm&type=Date)](https://www.star-history.com/#GeeeekExplorer/nano-vllm&Date)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ A lightweight vLLM implementation built from scratch.
 pip install git+https://github.com/GeeeekExplorer/nano-vllm.git
 ```
 
+## Manual download
+
+If you’d rather fetch the model weights yourself, you can use:
+```bash
+huggingface-cli download --resume-download Qwen/Qwen3-0.6B \
+  --local-dir ~/huggingface/Qwen3-0.6B/ \
+  --local-dir-use-symlinks False
+```
+
 ## Quick Start
 
 See `example.py` for usage. The API mirrors vLLM's interface with minor differences in the `LLM.generate` method.
@@ -42,8 +51,3 @@ See `bench.py` for benchmark.
 |----------------|-------------|----------|-----------------------|
 | vLLM           | 133,966     | 98.37    | 1361.84               |
 | Nano-vLLM      | 133,966     | 93.41    | 1434.13               |
-
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=GeeeekExplorer/nano-vllm&type=Date)](https://www.star-history.com/#GeeeekExplorer/nano-vllm&Date)


### PR DESCRIPTION
As requested in #26[](https://github.com/GeeeekExplorer/nano-vllm/pull/26), adds a new Manual download section to the README.md with a huggingface-cli snippet for fetching the Qwen3-0.6B weights manually. This helps users who prefer or need to download the model themselves.