### PR TITLE
Update pyproject.toml to fix missing files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,5 +22,6 @@ dependencies = [
 [project.urls]
 Homepage="https://github.com/GeeeekExplorer/nano-vllm"
 
-[tool.setuptools]
-packages = ["nanovllm"]
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["nanovllm*"]


### PR DESCRIPTION
Previously, running the example installation script in README would not correctly copy the directories such as `engine` to `site-packages`, causing missing files during import. This fixes that.

Installation is still the same:
```
pip install git+https://github.com/GeeeekExplorer/nano-vllm.git
```

With the PR it copies the right files to site-packages.