### PR TITLE
fix(model_runner): correct position indexing to be 0-based

### DIFF
--- a/nanovllm/engine/model_runner.py
+++ b/nanovllm/engine/model_runner.py
@@ -167,7 +167,7 @@ class ModelRunner:
         context_lens = []
         for seq in seqs:
             input_ids.append(seq.last_token)
-            positions.append(len(seq))
+            positions.append(len(seq) - 1)
             context_lens.append(len(seq))
             slot_mapping.append(seq.block_table[-1] * self.block_size + seq.last_block_num_tokens  - 1)
         input_ids = torch.tensor(input_ids, dtype=torch.int64, pin_memory=True).cuda(non_blocking=True)


### PR DESCRIPTION
https://github.com/GeeeekExplorer/nano-vllm/blob/38baf0bbe4bef79c7817a4643eade460acfac321/nanovllm/engine/model_runner.py#L170

There the `positions` is incorrect. It should be `len(seq) - 1` as the last token position.