### PR TITLE
Fix: Correct num_cached_tokens counting logic in BlockManager.allocate

### DIFF
--- a/nanovllm/engine/block_manager.py
+++ b/nanovllm/engine/block_manager.py
@@ -69,11 +69,11 @@ class BlockManager:
             if cache_miss:
                 block_id = self.free_block_ids[0]
                 block = self._allocate_block(block_id)
-            else:
-                seq.num_cached_tokens += self.block_size
+            else:              
                 if block_id in self.used_block_ids:
                     block = self.blocks[block_id]
                     block.ref_count += 1
+                    seq.num_cached_tokens += self.block_size
                 else:
                     block = self._allocate_block(block_id)
             if h != -1:


### PR DESCRIPTION
**File Modified**: `engine/block_manager.py` - Adjusted the timing of seq.num_cached_tokens increment in the `allocate` method 

**Reason for Modification**:
In the original logic, `num_cached_tokens` was incremented directly when `cache_miss=False` (hash hit and token match), but it failed to account for potential **stale entries** in the `hash_to_block_id map`. Specifically, a block ID might exist in the hash map but have already been released (no longer in `used_block_ids`) because its reference count dropped to 0. In such cases, `_allocate_block` would be triggered to reinitialize the block—this is essentially a "new allocation" rather than "cache reuse," yet it was incorrectly counted as cached tokens. 

**Fix Logic**:
Moved `seq.num_cached_tokens += self.block_size` into the `if block_id in self.used_block_ids:` branch. This ensures `num_cached_tokens` is only incremented when the block is **actually in use** (not released) and reused, fully aligning with its intended semantic of "counting truly reused cached tokens." 

**Impact**:
Fixes the statistical error in cache utilization, making `num_cached_tokens` accurately reflect real cache reuse (facilitating subsequent performance analysis). Does not affect the core logic of KV cache allocation/reuse; no functional risks.