### PR TITLE
Add FuseMoeLinear and support Qwen3-Moe

### DIFF
--- a/nanovllm/layers/fuse_moe/__init__.py
+++ b/nanovllm/layers/fuse_moe/__init__.py
@@ -1,0 +1,8 @@
+from .layer import (
+    ReplicatedFusedMoeLinear,
+    RowParallelFusedMoeLinear,
+    ColumnParallelFusedMoeLinear,
+    MergedColumnParallelFusedMoeLinear,
+)
+from .indexing import get_expert_counts_and_idx
+from .functional import fused_moe_linear

--- a/nanovllm/layers/fuse_moe/autotuning.py
+++ b/nanovllm/layers/fuse_moe/autotuning.py
@@ -1,0 +1,106 @@
+import os
+from itertools import product
+from typing import Any
+
+import torch
+import triton
+
+
+DEFAULT_M_BLOCK_SIZES = [16, 32, 64, 128, 256]
+DEFAULT_N_BLOCK_SIZES = [16, 32, 64, 128, 256]
+DEFAULT_K_BLOCK_SIZES = [16, 32, 64, 128, 256]
+DEFAULT_NUM_WARPS = [4, 8]
+DEFAULT_NUM_STAGES = [3, 4, 5, 6]
+
+
+def get_num_sms() -> int:
+    return torch.cuda.get_device_properties("cuda").multi_processor_count
+
+
+def get_autotune_configs() -> list[triton.Config]:
+    configs = []
+    for m, n, k, w, s in product(
+        DEFAULT_M_BLOCK_SIZES,
+        DEFAULT_N_BLOCK_SIZES,
+        DEFAULT_K_BLOCK_SIZES,
+        DEFAULT_NUM_WARPS,
+        DEFAULT_NUM_STAGES,
+    ):
+        configs.append(
+            triton.Config({"BLOCK_SIZE_M": m, "BLOCK_SIZE_N": n, "BLOCK_SIZE_K": k}, num_warps=w, num_stages=s)
+        )
+    return configs
+
+
+def _get_device_properties() -> dict[str, Any]:
+    return triton.runtime.driver.active.utils.get_device_properties(torch.cuda.current_device())
+
+
+def _exceeds_smem_capacity(
+    num_stages: int,
+    BLOCK_SIZE_M: int,
+    BLOCK_SIZE_N: int,
+    BLOCK_SIZE_K: int,
+    dtype: torch.dtype,
+    smem_size: int,
+    slack: int = 0,
+) -> bool:
+    return (
+        num_stages * BLOCK_SIZE_K * (BLOCK_SIZE_M + BLOCK_SIZE_N) + BLOCK_SIZE_M * BLOCK_SIZE_N
+    ) * dtype.itemsize > smem_size + slack
+
+
+def _common_prune_criteria(config: triton.Config, kwargs: dict[str, Any]) -> bool:
+    num_stages = config.num_stages
+    BLOCK_SIZE_M = config.kwargs["BLOCK_SIZE_M"]
+    BLOCK_SIZE_N = config.kwargs["BLOCK_SIZE_N"]
+    BLOCK_SIZE_K = config.kwargs["BLOCK_SIZE_K"]
+    dtype = kwargs["x_ptr"].dtype
+    device_properties = _get_device_properties()
+    smem_size = device_properties["max_shared_mem"]
+    if _exceeds_smem_capacity(num_stages, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, dtype, smem_size):
+        return True
+
+    M = kwargs["M"]
+    N = kwargs["N"]
+    K = kwargs["K"]
+    num_experts = kwargs["NUM_EXPERTS"]
+    tokens_per_expert = M // num_experts
+    max_block_size_M = max(tokens_per_expert * 2, DEFAULT_M_BLOCK_SIZES[0])
+    max_block_size_N = max(N, DEFAULT_N_BLOCK_SIZES[0])
+    max_block_size_K = max(K, DEFAULT_K_BLOCK_SIZES[0])
+    if BLOCK_SIZE_M > max_block_size_M:
+        return True
+    if BLOCK_SIZE_N > max_block_size_N:
+        return True
+    if BLOCK_SIZE_K > max_block_size_K:
+        return True
+
+    min_block_size_M = min(triton.next_power_of_2(tokens_per_expert // 2 + 1), 64)
+    min_block_size_N = min(triton.next_power_of_2(N // 2 + 1), 64)
+    min_block_size_K = min(triton.next_power_of_2(K // 2 + 1), 64)
+    if BLOCK_SIZE_M * BLOCK_SIZE_N < min_block_size_M * min_block_size_N:
+        return True
+    if BLOCK_SIZE_M * BLOCK_SIZE_K < min_block_size_M * min_block_size_K:
+        return True
+    if BLOCK_SIZE_N * BLOCK_SIZE_K < min_block_size_N * min_block_size_K:
+        return True
+
+    return False
+
+
+def prune_configs(configs: list[triton.Config], args, **kwargs) -> list[triton.Config]:
+    pruned_configs = []
+    for config in configs:
+        if _common_prune_criteria(config, args):
+            continue
+        pruned_configs.append(config)
+    return pruned_configs
+
+
+# We need to autotune on batch size only when benchmarking with a large range of batch sizes
+def get_autotune_keys() -> list[str]:
+    if os.getenv("AUTOTUNE_BATCH_SIZE", "0") == "1":
+        return ["M", "N", "K", "NUM_EXPERTS"]
+    else:
+        return ["N", "K", "NUM_EXPERTS"]

--- a/nanovllm/layers/fuse_moe/functional.py
+++ b/nanovllm/layers/fuse_moe/functional.py
@@ -1,0 +1,11 @@
+import torch
+
+from .grouped_gemm import grouped_gemm_forward
+
+
+def fused_moe_linear(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    m_sizes: torch.Tensor
+    ) -> torch.Tensor:
+    return grouped_gemm_forward(input, weight, m_sizes)

--- a/nanovllm/layers/fuse_moe/grouped_gemm.py
+++ b/nanovllm/layers/fuse_moe/grouped_gemm.py
@@ -1,0 +1,156 @@
+import torch
+import triton
+import triton.language as tl
+
+from .autotuning import (
+    get_autotune_configs,
+    get_autotune_keys,
+    get_num_sms,
+    prune_configs,
+)
+
+
+@triton.autotune(
+    configs=get_autotune_configs(),
+    prune_configs_by={"early_config_prune": prune_configs},
+    key=get_autotune_keys(),
+)
+@triton.jit
+def _grouped_gemm_forward_kernel(
+    # Pointers
+    x_ptr,
+    w_ptr,
+    m_sizes_ptr,
+    y_ptr,
+    # Dimensions
+    M: int,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    NUM_EXPERTS: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+    # Strides
+    stride_xm: tl.constexpr,
+    stride_xk: tl.constexpr,
+    stride_we: tl.constexpr,
+    stride_wn: tl.constexpr,
+    stride_wk: tl.constexpr,
+    stride_ym: tl.constexpr,
+    stride_yn: tl.constexpr,
+    # Metadata
+    BLOCK_SIZE_M: tl.constexpr = 64,
+    BLOCK_SIZE_N: tl.constexpr = 64,
+    BLOCK_SIZE_K: tl.constexpr = 64,
+) -> None:
+    tidx = tl.program_id(0)
+    m_end = 0
+    processed_tiles = 0
+    for expert_idx in range(NUM_EXPERTS):
+        m_start = m_end
+        m_size = tl.load(m_sizes_ptr + expert_idx).to(tl.int32)
+        m_end = m_start + m_size
+        if m_size > 0:
+            # tiles for this group's GEMM
+            num_m_tiles = tl.cdiv(m_size, BLOCK_SIZE_M)
+            num_n_tiles = tl.cdiv(N, BLOCK_SIZE_N)
+            num_tiles_per_expert = num_m_tiles * num_n_tiles
+
+            # Lower bound and upper bound are defined relative to the total tiles processed so far
+            # This ensures that we are only processing tiles for the current expert group AND
+            # we never exceed the total number of tiles for all expert groups
+            while tidx >= processed_tiles and tidx < processed_tiles + num_tiles_per_expert:
+                tile_idx = tidx - processed_tiles
+
+                # Output tile for this thread block for this expert group
+                # TODO: Check if L2 cache re-use for this order is optimal
+                tile_m_idx = tile_idx % num_m_tiles
+                tile_n_idx = tile_idx // num_m_tiles
+
+                offs_k = tl.arange(0, BLOCK_SIZE_K)
+
+                offs_m = m_start + tile_m_idx * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+                x_ptrs = x_ptr + stride_xm * offs_m[:, None] + stride_xk * offs_k[None, :]
+                mask_m = offs_m < m_end
+
+                offs_n = tile_n_idx * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+                w_ptrs = w_ptr + stride_we * expert_idx + stride_wn * offs_n[:, None] + stride_wk * offs_k[None, :]
+                mask_n = offs_n < N
+
+                accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+                # GEMM main loop
+                for _ in range(tl.cdiv(K, BLOCK_SIZE_K)):
+                    mask_k = offs_k < K
+                    x = tl.load(x_ptrs, mask=mask_m[:, None] & mask_k[None, :])
+                    w = tl.load(w_ptrs, mask=mask_n[:, None] & mask_k[None, :])
+
+                    accumulator += tl.dot(x, w.T)
+
+                    offs_k += BLOCK_SIZE_K
+                    x_ptrs += stride_xk * BLOCK_SIZE_K
+                    w_ptrs += stride_wk * BLOCK_SIZE_K
+                y = accumulator.to(y_ptr.dtype.element_ty)
+
+                y_ptrs = y_ptr + stride_ym * offs_m[:, None] + stride_yn * offs_n[None, :]
+                tl.store(y_ptrs, y, mask=mask_m[:, None] & mask_n[None, :])
+
+                # Move to the next tile within this expert group
+                tidx += NUM_SMS
+
+            # Update the total tiles count for the next expert group
+            processed_tiles += num_tiles_per_expert
+
+
+def is_int_tensor(x: torch.Tensor) -> bool:
+    return x.dtype in {
+        torch.uint8,
+        torch.int8,
+        torch.int16,
+        torch.int32,
+        torch.int64,
+    }
+
+
+def grouped_gemm_forward(
+    x: torch.Tensor, w: torch.Tensor, m_sizes: torch.Tensor, dtype: torch.dtype | None = None
+) -> torch.Tensor:
+    assert x.is_cuda
+    assert w.device == x.device
+    assert m_sizes.device == x.device
+    assert is_int_tensor(m_sizes)
+    assert x.is_contiguous()
+    assert w.is_contiguous()
+    assert m_sizes.is_contiguous()
+    assert x.ndim == 2
+    assert w.ndim == 3
+    assert m_sizes.ndim == 1
+    M, K = x.shape
+    E, N, _ = w.shape
+    assert w.shape[2] == K
+    assert m_sizes.numel() == E
+
+    if dtype is None:
+        dtype = x.dtype
+    y = torch.empty((M, N), device=x.device, dtype=dtype)
+    NUM_SMS = get_num_sms()
+    grid = lambda META: (NUM_SMS,)
+    _grouped_gemm_forward_kernel[grid](
+        # Pointers
+        x,
+        w,
+        m_sizes,
+        y,
+        # Dimensions
+        M,
+        N,
+        K,
+        E,
+        NUM_SMS,
+        # Strides
+        x.stride(0),
+        x.stride(1),
+        w.stride(0),
+        w.stride(1),
+        w.stride(2),
+        y.stride(0),
+        y.stride(1),
+    )
+    return y

--- a/nanovllm/layers/fuse_moe/indexing.py
+++ b/nanovllm/layers/fuse_moe/indexing.py
@@ -1,0 +1,21 @@
+from functools import partial
+
+import torch
+
+
+@partial(torch.compile, fullgraph=True, mode="max-autotune-no-cudagraphs")
+@torch.no_grad()
+def get_expert_counts_and_idx(s: torch.Tensor, E: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    E_arange = torch.arange(E, device=s.device, dtype=s.dtype)
+    compare = E_arange[:, None] == s[None, :]
+    counts = compare.sum(dim=1, dtype=torch.int32)
+
+    s_arange = torch.arange(s.numel(), device=s.device, dtype=s.dtype)
+    ranks_in_bin = compare.cumsum(dim=1, dtype=torch.int32)
+    ranks_in_bin = ranks_in_bin[s, s_arange]
+    offsets = counts.cumsum(dim=0, dtype=torch.int32) - counts
+    idx = ranks_in_bin + offsets[s] - 1
+
+    inv_idx = torch.empty_like(idx)
+    inv_idx[idx] = s_arange.to(inv_idx.dtype)
+    return counts, inv_idx, idx

--- a/nanovllm/layers/fuse_moe/layer.py
+++ b/nanovllm/layers/fuse_moe/layer.py
@@ -1,0 +1,126 @@
+import torch
+from torch import nn
+import torch.distributed as dist
+
+from nanovllm.layers.fuse_moe.functional import fused_moe_linear
+
+
+def divide(numerator, denominator):
+    assert numerator % denominator == 0, f"{numerator=} % {denominator=} != 0"
+    return numerator // denominator
+
+
+class FusedMoeLinearBase(nn.Module):
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        num_experts: int,
+        bias: bool = False,
+        tp_dim: int | None = None,
+    ) -> None:
+        super().__init__()
+        self.tp_dim = tp_dim
+        self.tp_rank = dist.get_rank()
+        self.tp_size = dist.get_world_size()
+
+        self.in_features = in_features
+        self.out_features = out_features
+        self.num_experts = num_experts
+
+        self.weight = nn.Parameter(
+            torch.empty((num_experts, out_features, in_features))
+        )
+        self.weight.weight_loader = self.weight_loader
+
+        if bias:
+            self.bias = nn.Parameter(torch.empty((num_experts, out_features)))
+            self.bias.weight_loader = self.weight_loader
+        else:
+            self.register_parameter("bias", None)
+
+    def forward(self, x: torch.Tensor, m_sizes: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+
+class ReplicatedFusedMoeLinear(FusedMoeLinearBase):
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        num_experts: int,
+        bias: bool = False,
+    ) -> None:
+        super().__init__(in_features, out_features, num_experts, bias)
+
+    def weight_loader(self, param: nn.Parameter, loaded_weight: torch.Tensor, expert_idx: int):
+        param.data[expert_idx].copy_(loaded_weight)
+
+    def forward(self, x: torch.Tensor, m_sizes: torch.Tensor) -> torch.Tensor:
+        return fused_moe_linear(x, self.weight, m_sizes)
+
+
+class ColumnParallelFusedMoeLinear(FusedMoeLinearBase):
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        num_experts: int,
+        bias: bool = False,
+    ) -> None:
+        tp_size = dist.get_world_size() if dist.is_initialized() else 1
+        super().__init__(in_features, divide(out_features, tp_size), num_experts, bias, 1)
+
+    def weight_loader(self, param: nn.Parameter, loaded_weight: torch.Tensor, expert_idx: int):
+        shard_size = param.size(1)
+        start_idx = self.tp_rank * shard_size
+        local_shard = loaded_weight[start_idx : start_idx + shard_size, :]
+        param.data[expert_idx].copy_(local_shard)
+
+    def forward(self, x: torch.Tensor, m_sizes: torch.Tensor) -> torch.Tensor:
+        return fused_moe_linear(x, self.weight, m_sizes)
+    
+
+class RowParallelFusedMoeLinear(FusedMoeLinearBase):
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        num_experts: int,
+        bias: bool = False,
+    ) -> None:
+        tp_size = dist.get_world_size() if dist.is_initialized() else 1
+        super().__init__(divide(in_features, tp_size), out_features, num_experts, bias, 2)
+
+    def weight_loader(self, param: nn.Parameter, loaded_weight: torch.Tensor, expert_idx: int):
+        shard_size = param.size(2)
+        start_idx = self.tp_rank * shard_size
+        local_shard = loaded_weight[:, start_idx : start_idx + shard_size]
+        param.data[expert_idx].copy_(local_shard)
+
+    def forward(self, x: torch.Tensor, m_sizes: torch.Tensor) -> torch.Tensor:
+        y = fused_moe_linear(x, self.weight, m_sizes)
+        if self.tp_size > 1:
+            dist.all_reduce(y)
+        return y
+
+
+class MergedColumnParallelFusedMoeLinear(ColumnParallelFusedMoeLinear):
+    def __init__(
+        self,
+        in_features: int,
+        out_feature_list: list[int],
+        num_experts: int,
+        bias: bool = False,
+    ):
+        self.out_feature_list = out_feature_list
+        super().__init__(in_features, sum(out_feature_list), num_experts, bias)
+
+    def weight_loader(self, param: nn.Parameter, loaded_weight: torch.Tensor, expert_idx: int, shard_id: int):
+        param_data = param.data
+        shard_offset = sum(self.out_feature_list[:shard_id]) // self.tp_size
+        shard_size = self.out_feature_list[shard_id] // self.tp_size
+        param_data = param_data.narrow(self.tp_dim, shard_offset, shard_size)
+        local_weight = loaded_weight.chunk(self.tp_size, dim=self.tp_dim)[self.tp_rank]
+        param_data[expert_idx] = local_weight

--- a/nanovllm/models/__init__.py
+++ b/nanovllm/models/__init__.py
@@ -1,0 +1,2 @@
+from .qwen3 import Qwen3ForCausalLM, Qwen3Model
+from .qwen3_moe import Qwen3MoeForCausalLM, Qwen3MoeModel

--- a/nanovllm/models/qwen3.py
+++ b/nanovllm/models/qwen3.py
@@ -1,8 +1,13 @@
+import os
+from glob import glob
+
 import torch
 from torch import nn
 import torch.distributed as dist
+from safetensors import safe_open
 from transformers import Qwen3Config
 
+from nanovllm.utils.loader import default_weight_loader
 from nanovllm.layers.activation import SiluAndMul
 from nanovllm.layers.attention import Attention
 from nanovllm.layers.layernorm import RMSNorm
@@ -208,3 +213,33 @@ class Qwen3ForCausalLM(nn.Module):
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
         return self.lm_head(hidden_states)
+
+    def load_model(
+        self,
+        path: str,
+    ) -> None:
+        for file in glob(os.path.join(path, "*.safetensors")):
+            with safe_open(file, "pt", "cpu") as f:
+                for weight_name in f.keys():
+                    weight_tensor = f.get_tensor(weight_name)
+                    is_loaded = False
+
+                    # Load packed modules
+                    for k in self.packed_modules_mapping:
+                        if k in weight_name:
+                            v, shard_id = self.packed_modules_mapping[k]
+                            param_name = weight_name.replace(k, v)
+                            param = self.get_parameter(param_name)
+                            weight_loader = getattr(param, "weight_loader")
+                            weight_loader(param, weight_tensor, shard_id)
+                            is_loaded = True
+                            break
+
+                    # Load other modules
+                    if not is_loaded:
+                        param = self.get_parameter(weight_name)
+                        weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                        weight_loader(param, weight_tensor)
+                        is_loaded = True
+
+                    assert is_loaded, f"Weight {weight_name} not loaded"

--- a/nanovllm/models/qwen3_moe.py
+++ b/nanovllm/models/qwen3_moe.py
@@ -1,0 +1,408 @@
+import os
+from glob import glob
+
+import torch
+from torch import nn
+import torch.distributed as dist
+from safetensors import safe_open
+from transformers import Qwen3MoeConfig
+
+from nanovllm.utils.loader import default_weight_loader
+from nanovllm.layers.activation import SiluAndMul
+from nanovllm.layers.attention import Attention
+from nanovllm.layers.layernorm import RMSNorm
+from nanovllm.layers.linear import QKVParallelLinear, MergedColumnParallelLinear, RowParallelLinear
+from nanovllm.layers.rotary_embedding import get_rope
+from nanovllm.layers.fuse_moe import MergedColumnParallelFusedMoeLinear, RowParallelFusedMoeLinear, get_expert_counts_and_idx
+from nanovllm.layers.embed_head import VocabParallelEmbedding, ParallelLMHead
+
+
+class Qwen3MoeAttention(nn.Module):
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        max_position: int = 4096 * 32,
+        head_dim: int | None = None,
+        rms_norm_eps: float = 1e-06,
+        qkv_bias: bool = False,
+        rope_theta: float = 10000,
+        rope_scaling: tuple | None = None,
+        sliding_window: int | None = None,
+    ) -> None:
+        super().__init__()
+        tp_size = dist.get_world_size()
+        self.total_num_heads = num_heads
+        assert self.total_num_heads % tp_size == 0
+        self.num_heads = self.total_num_heads // tp_size
+        self.total_num_kv_heads = num_kv_heads
+        assert self.total_num_kv_heads % tp_size == 0
+        self.num_kv_heads = self.total_num_kv_heads // tp_size
+        self.head_dim = head_dim or hidden_size // self.total_num_heads
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.scaling = self.head_dim ** -0.5
+        self.sliding_window = sliding_window
+
+        self.qkv_proj = QKVParallelLinear(
+            hidden_size,
+            self.head_dim,
+            self.total_num_heads,
+            self.total_num_kv_heads,
+            bias=qkv_bias,
+        )
+        self.o_proj = RowParallelLinear(
+            self.total_num_heads * self.head_dim,
+            hidden_size,
+            bias=False,
+        )
+        self.rotary_emb = get_rope(
+            self.head_dim,
+            rotary_dim=self.head_dim,
+            max_position=max_position,
+            base=rope_theta,
+            rope_scaling=rope_scaling,
+        )
+        self.attn = Attention(
+            self.num_heads,
+            self.head_dim,
+            self.scaling,
+            self.num_kv_heads,
+        )
+        self.q_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
+        self.k_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        qkv = self.qkv_proj(hidden_states)
+        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        q = self.q_norm(q.view(-1, self.num_heads, self.head_dim))
+        k = self.k_norm(k.view(-1, self.num_kv_heads, self.head_dim))
+        v = v.view(-1, self.num_kv_heads, self.head_dim)
+        q, k = self.rotary_emb(positions, q, k)
+        o = self.attn(q, k, v)
+        output = self.o_proj(o.flatten(1, -1))
+        return output
+
+
+class Qwen3MoeMLP(nn.Module):
+
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        hidden_act: str,
+    ) -> None:
+        super().__init__()
+        self.gate_up_proj = MergedColumnParallelLinear(
+            hidden_size,
+            [intermediate_size] * 2,
+            bias=False,
+        )
+        self.down_proj = RowParallelLinear(
+            intermediate_size,
+            hidden_size,
+            bias=False,
+        )
+        assert hidden_act == "silu"
+        self.act_fn = SiluAndMul()
+
+    def forward(self, x):
+        gate_up = self.gate_up_proj(x)
+        x = self.act_fn(gate_up)
+        x = self.down_proj(x)
+        return x
+
+
+class Qwen3MoeExperts(nn.ModuleList):
+
+    def __init__(
+        self,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size: int,
+        hidden_act: str,
+    ) -> None:
+        super().__init__()
+        self.num_experts = num_experts
+        for _ in range(self.num_experts):
+            self.append(Qwen3MoeMLP(hidden_size, intermediate_size, hidden_act))
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        top_k_index: torch.Tensor,
+        top_k_weights: torch.Tensor,
+    ) -> torch.Tensor:
+        final_hidden_states = torch.zeros_like(hidden_states)
+        expert_mask = torch.nn.functional.one_hot(top_k_index, num_classes=self.num_experts).permute(2, 1, 0)
+
+        expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
+        for expert_idx in expert_hit:
+            idx, top_x = torch.where(expert_mask[expert_idx].squeeze(0))
+            current_state = hidden_states[None, top_x].reshape(-1, hidden_states.shape[-1])
+            current_hidden_states = self[expert_idx](current_state) * top_k_weights[top_x, idx, None]
+            final_hidden_states.index_add_(0, top_x, current_hidden_states.to(hidden_states.dtype))
+        return final_hidden_states
+
+class Qwen3MoeSparseMoeBlock(nn.Module):
+    def __init__(
+        self,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size: int,
+        num_experts_per_tok: int,
+        norm_topk_prob: bool,
+        hidden_act: str,
+    ) -> None:
+        super().__init__()
+        self.gate = RowParallelLinear(hidden_size, num_experts, bias=False)
+        self.experts = Qwen3MoeExperts(num_experts, hidden_size, intermediate_size, hidden_act)
+        self.num_experts_per_tok = num_experts_per_tok
+        self.norm_topk_prob = norm_topk_prob
+
+    def route_tokens_to_experts(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        routing_weights = nn.functional.softmax(router_logits, dim=-1, dtype=torch.float)
+        routing_weights, selected_experts = torch.topk(routing_weights, self.num_experts_per_tok, dim=-1)
+        if self.norm_topk_prob:
+            routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
+        routing_weights = routing_weights.to(hidden_states.dtype)
+        return selected_experts, routing_weights
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        router_logits = self.gate(hidden_states)
+        selected_experts, routing_weights = self.route_tokens_to_experts(hidden_states, router_logits)
+        final_hidden_states = self.experts(hidden_states, selected_experts, routing_weights)
+        return final_hidden_states
+
+
+class Qwen3MoeFusedSparseMoeBlock(nn.Module):
+    def __init__(
+        self,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size: int,
+        num_experts_per_tok: int,
+        norm_topk_prob: bool,
+        hidden_act: str,
+    ) -> None:
+        super().__init__()
+        self.num_experts = num_experts
+        self.num_selected = num_experts_per_tok
+        self.norm_topk_prob = norm_topk_prob
+        self.hidden_size = hidden_size
+        self.moe_intermediate_size = intermediate_size
+
+        self.gate = RowParallelLinear(hidden_size, num_experts, bias=False)
+        self.gate_up_proj = MergedColumnParallelFusedMoeLinear(hidden_size, [intermediate_size] * 2, num_experts)
+        self.down_proj = RowParallelFusedMoeLinear(intermediate_size, hidden_size, num_experts)
+        self.act_fn = SiluAndMul()
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        M, hidden_dim = hidden_states.shape
+        router_logits = self.gate(hidden_states)
+        routing_weights = nn.functional.softmax(router_logits, dim=1, dtype=torch.float32)
+        routing_weights, selected_experts = torch.topk(routing_weights, self.num_selected, dim=-1)
+
+        if self.norm_topk_prob:
+            routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
+        routing_weights = routing_weights.to(hidden_states.dtype)
+
+        expanded_hidden = hidden_states.repeat_interleave(self.num_selected, dim=0)
+        selected_experts = selected_experts.reshape(-1)
+        m_sizes, sort_idx, inv_sort_idx = get_expert_counts_and_idx(
+            selected_experts, self.num_experts
+        )
+
+        expanded_hidden = expanded_hidden[sort_idx]
+        gate_up = self.gate_up_proj(expanded_hidden, m_sizes)
+        expert_output = self.down_proj(self.act_fn(gate_up), m_sizes)
+        expert_output = expert_output[inv_sort_idx]
+        expert_output = expert_output.view(M, self.num_selected, hidden_dim)
+        output = (expert_output * routing_weights.unsqueeze(-1)).sum(dim=1)
+
+        return output
+
+
+# Qwen3MoeSparseMoeBlock
+class Qwen3MoeBlock(Qwen3MoeFusedSparseMoeBlock):
+    pass
+
+
+class Qwen3MoeRMSNorm(RMSNorm):
+    pass
+
+
+class Qwen3MoeDecoderLayer(nn.Module):
+
+    def __init__(
+        self,
+        config: Qwen3MoeConfig,
+        layer_idx: int,
+    ) -> None:
+        super().__init__()
+        self.self_attn = Qwen3MoeAttention(
+            hidden_size=config.hidden_size,
+            num_heads=config.num_attention_heads,
+            num_kv_heads=config.num_key_value_heads,
+            max_position=config.max_position_embeddings,
+            head_dim=getattr(config, "head_dim", None),
+            rms_norm_eps=config.rms_norm_eps,
+            qkv_bias=getattr(config, 'attention_bias', False),
+            rope_theta=config.rope_theta,
+            rope_scaling=config.rope_scaling,
+            sliding_window=config.sliding_window,
+        )
+        if (layer_idx not in config.mlp_only_layers) and (
+            config.num_experts > 0 and (layer_idx + 1) % config.decoder_sparse_step == 0
+        ):
+            self.mlp = Qwen3MoeBlock(
+                num_experts=config.num_experts,
+                hidden_size=config.hidden_size,
+                intermediate_size=config.moe_intermediate_size,
+                num_experts_per_tok=config.num_experts_per_tok,
+                norm_topk_prob=config.norm_topk_prob,
+                hidden_act=config.hidden_act,
+            )
+        else:
+            self.mlp = Qwen3MoeMLP(
+                hidden_size=config.hidden_size,
+                intermediate_size=config.intermediate_size,
+                hidden_act=config.hidden_act,
+            )
+        self.input_layernorm = Qwen3MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = Qwen3MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> torch.Tensor:
+        # Self Attention
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(positions, hidden_states)
+        hidden_states = residual + hidden_states
+
+        # Fully Connected
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+class Qwen3MoeModel(nn.Module):
+
+    def __init__(
+        self,
+        config: Qwen3MoeConfig,
+    ) -> None:
+        super().__init__()
+        self.embed_tokens = VocabParallelEmbedding(config.vocab_size, config.hidden_size)
+        self.layers = nn.ModuleList([Qwen3MoeDecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
+        self.norm = Qwen3MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        hidden_states = self.embed_tokens(input_ids)
+        for decoder_layer in self.layers:
+            hidden_states = decoder_layer(
+                hidden_states,
+                position_ids,
+            )
+        hidden_states = self.norm(hidden_states)
+        return hidden_states
+
+
+class Qwen3MoeForCausalLM(nn.Module):
+    packed_modules_mapping = {
+        "q_proj": ("qkv_proj", "q"),
+        "k_proj": ("qkv_proj", "k"),
+        "v_proj": ("qkv_proj", "v"),
+        "gate_proj": ("gate_up_proj", 0),
+        "up_proj": ("gate_up_proj", 1),
+    }
+
+    def __init__(
+        self,
+        config: Qwen3MoeConfig,
+    ) -> None:
+        super().__init__()
+        self.model = Qwen3MoeModel(config)
+        self.num_experts = config.num_experts
+        self.lm_head = ParallelLMHead(config.vocab_size, config.hidden_size)
+        if config.tie_word_embeddings:
+            self.lm_head.weight.data = self.model.embed_tokens.weight.data
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        return self.model(input_ids, position_ids)
+    
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        return self.lm_head(hidden_states)
+
+    def load_model(
+        self,
+        path: str,
+    ) -> None:
+        for file in glob(os.path.join(path, "*.safetensors")):
+            with safe_open(file, "pt", "cpu") as f:
+                for weight_name in f.keys():
+                    weight_tensor = f.get_tensor(weight_name)
+                    is_expert = "mlp.experts" in weight_name
+                    is_loaded = False
+
+                    # Process experts params name
+                    if is_expert:
+                        mlp_module_name, expert_module_name = weight_name.split(".experts.")
+                        expert_idx = int(expert_module_name.split(".")[0])
+                        proj_name = expert_module_name.replace(f"{expert_idx}.", "")
+                        weight_name = f"{mlp_module_name}.{proj_name}"
+
+                    # Load packed modules
+                    for k in self.packed_modules_mapping:
+                        if k in weight_name:
+                            v, shard_id = self.packed_modules_mapping[k]
+                            param_name = weight_name.replace(k, v)
+                            param = self.get_parameter(param_name)
+                            weight_loader = getattr(param, "weight_loader")
+                            if is_expert:
+                                weight_loader(param, weight_tensor, expert_idx, shard_id)
+                            else:
+                                weight_loader(param, weight_tensor, shard_id)
+                            is_loaded = True
+                            break
+
+                    # Load other modules
+                    if not is_loaded:
+                        param = self.get_parameter(weight_name)
+                        weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                        if is_expert:
+                            weight_loader(param, weight_tensor, expert_idx)
+                        else:
+                            weight_loader(param, weight_tensor)
+                        is_loaded = True
+                    
+                    assert is_loaded, f"Weight {weight_name} not loaded"

--- a/nanovllm/utils/loader.py
+++ b/nanovllm/utils/loader.py
@@ -1,8 +1,5 @@
-import os
-from glob import glob
 import torch
 from torch import nn
-from safetensors import safe_open
 
 
 def default_weight_loader(param: nn.Parameter, loaded_weight: torch.Tensor):
@@ -10,19 +7,4 @@ def default_weight_loader(param: nn.Parameter, loaded_weight: torch.Tensor):
 
 
 def load_model(model: nn.Module, path: str):
-    packed_modules_mapping = getattr(model, "packed_modules_mapping", {})
-    for file in glob(os.path.join(path, "*.safetensors")):
-        with safe_open(file, "pt", "cpu") as f:
-            for weight_name in f.keys():
-                for k in packed_modules_mapping:
-                    if k in weight_name:
-                        v, shard_id = packed_modules_mapping[k]
-                        param_name = weight_name.replace(k, v)
-                        param = model.get_parameter(param_name)
-                        weight_loader = getattr(param, "weight_loader")
-                        weight_loader(param, f.get_tensor(weight_name), shard_id)
-                        break
-                else:
-                    param = model.get_parameter(weight_name)
-                    weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                    weight_loader(param, f.get_tensor(weight_name))
+    model.load_model(path)


### PR DESCRIPTION


## PR Summary

This PR adds **Mixture-of-Experts (MoE)** support to **nano-vllm**, addressing the current lack of MoE-related operators.
The Qwen3 MoE model (and other MoE models) in Hugging Face Transformers are known to be **extremely slow**, mainly due to Python-level `for` loops over experts during the forward pass.
This PR introduces a fused Triton-based kernel and corresponding layer implementations to enable efficient MoE inference.

---

## Key Changes

1. **Added operator** `fused_moe_linear`

   * Location: `nanovllm/layers/fuse_moe`
   * Implementation is largely based on the MoE kernel in [Unsloth](https://github.com/unslothai/unsloth), which in turn uses Triton’s grouped GEMM.

2. **Added Linear layer wrappers** built on top of `fused_moe_linear`:

   * `ReplicatedFusedMoeLinear`
   * `ColumnParallelFusedMoeLinear`
   * `RowParallelFusedMoeLinear`
   * `MergedColumnParallelFusedMoeLinear`
     These enable seamless MoE integration in distributed model architectures.

3. **Introduced** `Qwen3MoeForCausalLM`

   * Enables running **Qwen3-MoE** models efficiently with nano-vllm
   * Designed to be extensible for other MoE-based models in the future

---

## Test Configuration

| Component          | Specification                            |
| ------------------ | ---------------------------------------- |
| **Model** | Qwen3-30B-A3B |
| **Hardware**       | A100-SXM4-80GB × 1                       |
| **Total Requests** | 8 / 256 sequences                            |
| **Input Length**   | Randomly sampled between 100–1024 tokens |
| **Output Length**  | Randomly sampled between 100–1024 tokens |

---

## Inference Results

| Model          | Output Tokens | Time (s)    | Throughput (tokens/s) |
| -------------- | ------------- | ----------- | --------------------- |
| Nano-vLLM      | 133,966       | 105.49  | **1269.94**           |
| Native HF Impl | 4,186         | 480.59  | 8.71                  |