### PR TITLE
Add Qwen3-VL multimodal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ huggingface-cli download --resume-download Qwen/Qwen3-0.6B \
   --local-dir-use-symlinks False
 ```
 
+For the multimodal Qwen3-VL-2B-Instruct checkpoint:
+```bash
+huggingface-cli download --resume-download Qwen/Qwen3-VL-2B-Instruct \
+  --local-dir ~/huggingface/Qwen3-VL-2B-Instruct/ \
+  --local-dir-use-symlinks False
+```
+
 ## Quick Start
 
 See `example.py` for usage. The API mirrors vLLM's interface with minor differences in the `LLM.generate` method:
@@ -42,6 +49,8 @@ prompts = ["Hello, Nano-vLLM."]
 outputs = llm.generate(prompts, sampling_params)
 outputs[0]["text"]
 ```
+
+For multimodal inference (vision + text), see `example_multimodal.py`.
 
 ## Benchmark
 

--- a/bench_multimodal.py
+++ b/bench_multimodal.py
@@ -1,0 +1,240 @@
+"""Benchmark script for nano-vllm multimodal inference."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import time
+import urllib.request
+from dataclasses import dataclass
+from typing import Iterable
+
+from PIL import Image
+
+from nanovllm import LLM, SamplingParams
+
+
+DEFAULT_IMAGE_URLS: tuple[str, ...] = (
+    # A subset of COCO validation images with diverse scenes.
+    "http://images.cocodataset.org/val2017/000000000285.jpg",
+    "http://images.cocodataset.org/val2017/000000000632.jpg",
+    "http://images.cocodataset.org/val2017/000000000724.jpg",
+    "http://images.cocodataset.org/val2017/000000000776.jpg",
+    "http://images.cocodataset.org/val2017/000000001000.jpg",
+    "http://images.cocodataset.org/val2017/000000001268.jpg",
+    "http://images.cocodataset.org/val2017/000000006012.jpg",
+    "http://images.cocodataset.org/val2017/000000190236.jpg",
+    "http://images.cocodataset.org/val2017/000000331352.jpg",
+    "http://images.cocodataset.org/val2017/000000517069.jpg",
+)
+
+DEFAULT_PROMPT = (
+    "Please describe the scene in the image and highlight the primary objects."
+)
+
+
+def get_env_float(name: str, default: float) -> float:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        return default
+
+
+def get_env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
+def download_image(url: str) -> Image.Image:
+    with urllib.request.urlopen(url) as response:
+        payload = response.read()
+    return Image.open(io.BytesIO(payload)).convert("RGB")
+
+
+@dataclass
+class BenchmarkResult:
+    num_requests: int
+    total_prompt_tokens: int
+    total_generated_tokens: int
+    latency: float
+
+    @property
+    def tok_per_sec(self) -> float:
+        if self.latency <= 0:
+            return 0.0
+        return self.total_generated_tokens / self.latency
+
+
+def build_requests(
+    processor,
+    image_urls: Iterable[str],
+    prompt: str,
+) -> list[dict]:
+    requests = []
+    for url in image_urls:
+        image = download_image(url)
+        chat_prompt = processor.apply_chat_template(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image", "image": image},
+                        {"type": "text", "text": prompt},
+                    ],
+                }
+            ],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        requests.append(
+            {
+                "text": chat_prompt,
+                "images": [image],
+                "meta": {"url": url},
+            }
+        )
+    return requests
+
+
+def run_benchmark(
+    model_path: str,
+    max_new_tokens: int,
+    temperature: float,
+    image_urls: Iterable[str],
+) -> BenchmarkResult:
+    llm = LLM(
+        model_path,
+        enforce_eager=True,
+        tensor_parallel_size=1,
+        is_multimodal=True,
+    )
+
+    # Imported lazily to avoid the dependency when this benchmark is unused.
+    from transformers import (  # pylint: disable=import-outside-toplevel
+        AutoProcessor,
+    )
+
+    processor = AutoProcessor.from_pretrained(model_path)
+
+    requests = build_requests(processor, image_urls, DEFAULT_PROMPT)
+    num_requests = len(requests)
+    sampling_params = SamplingParams(
+        temperature=temperature,
+        max_tokens=max_new_tokens,
+    )
+    sampling_params_list = [sampling_params] * num_requests
+
+    # Warm-up with a single request to exclude one-time costs.
+    llm.generate_multimodal(
+        [requests[0]],
+        sampling_params_list[0],
+        processor,
+        use_tqdm=False,
+    )
+
+    start = time.perf_counter()
+    outputs = llm.generate_multimodal(
+        requests,
+        sampling_params_list,
+        processor,
+        use_tqdm=False,
+    )
+    latency = time.perf_counter() - start
+
+    total_generated = sum(len(item["token_ids"]) for item in outputs)
+
+    # nano-vllm does not report prompt token lengths; estimate them here.
+    prompt_token_lengths = 0
+    for req in requests:
+        encoded = processor(
+            text=[req["text"]],
+            images=req["images"],
+            return_tensors="pt",
+        )
+        prompt_token_lengths += encoded["input_ids"].shape[-1]
+
+    return BenchmarkResult(
+        num_requests=num_requests,
+        total_prompt_tokens=prompt_token_lengths,
+        total_generated_tokens=total_generated,
+        latency=latency,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Benchmark nano-vllm multimodal inference."
+    )
+    default_out_seq = get_env_int("out_seq_length", 64)
+    default_temperature = get_env_float("temperature", 0.2)
+    parser.add_argument(
+        "--model",
+        type=str,
+        required=True,
+        help=(
+            "Path to the Qwen3-VL model directory "
+            "(the same path used by AutoProcessor)."
+        ),
+    )
+    parser.add_argument(
+        "--max-new-tokens",
+        type=int,
+        default=default_out_seq,
+        help="Maximum number of tokens to generate per request.",
+    )
+    parser.add_argument(
+        "--temperature",
+        type=float,
+        default=default_temperature,
+        help="Sampling temperature.",
+    )
+    parser.add_argument(
+        "--num-images",
+        type=int,
+        default=len(DEFAULT_IMAGE_URLS),
+        help=(
+            "Number of images to benchmark "
+            "(picked from a fixed COCO subset)."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    image_urls = DEFAULT_IMAGE_URLS[: args.num_images]
+    if not image_urls:
+        raise ValueError("num-images must be positive.")
+
+    result = run_benchmark(
+        model_path=args.model,
+        max_new_tokens=args.max_new_tokens,
+        temperature=args.temperature,
+        image_urls=image_urls,
+    )
+
+    print("=== nano-vllm multimodal benchmark ===")
+    print(f"Requests          : {result.num_requests}")
+    print(f"Prompt tokens     : {result.total_prompt_tokens}")
+    print(f"Generated tokens  : {result.total_generated_tokens}")
+    print(f"Latency           : {result.latency:.2f}s")
+    print(f"Throughput        : {result.tok_per_sec:.2f} tok/s")
+    if os.getenv("top_p") or os.getenv("top_k") or os.getenv("repetition_penalty"):
+        print(
+            "Note: Sampling parameters such as top_p/top_k/repetition_penalty "
+            "are not currently supported by nano-vllm and were ignored."
+        )
+
+
+if __name__ == "__main__":
+    main()
+

--- a/example_multimodal.py
+++ b/example_multimodal.py
@@ -1,0 +1,68 @@
+"""Minimal multimodal inference example using Qwen3-VL."""
+
+from __future__ import annotations
+
+import io
+import os
+import urllib.request
+
+from PIL import Image
+from transformers import AutoProcessor
+
+from nanovllm import LLM, SamplingParams
+
+
+DEFAULT_IMAGE_URL = "http://images.cocodataset.org/val2017/000000000285.jpg"
+DEFAULT_PROMPT = (
+    "Please describe the scene in the image and highlight the main objects."
+)
+
+
+def download_image(url: str) -> Image.Image:
+    with urllib.request.urlopen(url) as response:
+        data = response.read()
+    return Image.open(io.BytesIO(data)).convert("RGB")
+
+
+def main() -> None:
+    model_path = os.path.expanduser("~/huggingface/Qwen3-VL-2B-Instruct/")
+    llm = LLM(
+        model_path,
+        enforce_eager=True,
+        tensor_parallel_size=1,
+        is_multimodal=True,
+    )
+
+    processor = AutoProcessor.from_pretrained(model_path)
+    image = download_image(DEFAULT_IMAGE_URL)
+    chat_prompt = processor.apply_chat_template(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image", "image": image},
+                    {"type": "text", "text": DEFAULT_PROMPT},
+                ],
+            }
+        ],
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+
+    request = {"text": chat_prompt, "images": [image]}
+    sampling_params = SamplingParams(temperature=0.7, max_tokens=256)
+    outputs = llm.generate_multimodal(
+        [request],
+        sampling_params,
+        processor,
+        use_tqdm=False,
+    )
+
+    print("Prompt:", DEFAULT_PROMPT)
+    print("Image URL:", DEFAULT_IMAGE_URL)
+    print("Completion:", outputs[0]["text"])
+
+
+if __name__ == "__main__":
+    main()
+

--- a/nanovllm/config.py
+++ b/nanovllm/config.py
@@ -12,6 +12,7 @@ class Config:
     gpu_memory_utilization: float = 0.9
     tensor_parallel_size: int = 1
     enforce_eager: bool = False
+    is_multimodal: bool = False  # Enable multimodal support
     hf_config: AutoConfig | None = None
     eos: int = -1
     kvcache_block_size: int = 256
@@ -22,5 +23,25 @@ class Config:
         assert self.kvcache_block_size % 256 == 0
         assert 1 <= self.tensor_parallel_size <= 8
         self.hf_config = AutoConfig.from_pretrained(self.model)
-        self.max_model_len = min(self.max_model_len, self.hf_config.max_position_embeddings)
+
+        # Multimodal models (e.g. Qwen3-VL) store the text settings in
+        # hf_config.text_config.
+        text_config = getattr(self.hf_config, "text_config", self.hf_config)
+
+        max_position_embeddings = getattr(
+            text_config,
+            "max_position_embeddings",
+            None,
+        )
+        if max_position_embeddings is not None:
+            self.max_model_len = min(
+                self.max_model_len,
+                max_position_embeddings,
+            )
+
+        # eos may be defined within the text config
+        eos_token_id = getattr(text_config, "eos_token_id", None)
+        if eos_token_id is not None:
+            self.eos = eos_token_id
+
         assert self.max_num_batched_tokens >= self.max_model_len

--- a/nanovllm/engine/block_manager.py
+++ b/nanovllm/engine/block_manager.py
@@ -25,12 +25,20 @@ class Block:
 
 class BlockManager:
 
-    def __init__(self, num_blocks: int, block_size: int):
+    def __init__(
+        self,
+        num_blocks: int,
+        block_size: int,
+        non_cache_token_ids: list[int] | None = None,
+    ):
         self.block_size = block_size
         self.blocks: list[Block] = [Block(i) for i in range(num_blocks)]
         self.hash_to_block_id: dict[int, int] = dict()
         self.free_block_ids: deque[int] = deque(range(num_blocks))
         self.used_block_ids: set[int] = set()
+        # Tokens in this set should never trigger cache hits because their
+        # embeddings depend on per-request image features.
+        self.non_cache_token_ids: set[int] = set(non_cache_token_ids or [])
 
     @classmethod
     def compute_hash(cls, token_ids: list[int], prefix: int = -1):
@@ -62,6 +70,8 @@ class BlockManager:
         cache_miss = False
         for i in range(seq.num_blocks):
             token_ids = seq.block(i)
+            if any(token in self.non_cache_token_ids for token in token_ids):
+                cache_miss = True
             h = self.compute_hash(token_ids, h) if len(token_ids) == self.block_size else -1
             block_id = self.hash_to_block_id.get(h, -1)
             if block_id == -1 or self.blocks[block_id].token_ids != token_ids:

--- a/nanovllm/engine/llm_engine.py
+++ b/nanovllm/engine/llm_engine.py
@@ -3,6 +3,7 @@ from dataclasses import fields
 from time import perf_counter
 from tqdm.auto import tqdm
 from transformers import AutoTokenizer
+import torch
 import torch.multiprocessing as mp
 
 from nanovllm.config import Config
@@ -28,10 +29,96 @@ class LLMEngine:
             self.ps.append(process)
             self.events.append(event)
         self.model_runner = ModelRunner(config, 0, self.events)
-        self.tokenizer = AutoTokenizer.from_pretrained(config.model, use_fast=True)
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            config.model,
+            use_fast=True,
+        )
         config.eos = self.tokenizer.eos_token_id
         self.scheduler = Scheduler(config)
         atexit.register(self.exit)
+
+    def _expand_vision_placeholders(
+        self,
+        input_ids: list[int],
+        image_grid_thw: torch.Tensor,
+    ) -> tuple[list[int], list[int], list[tuple[int, int]]]:
+        """Expand vision placeholders according to the vision grid metadata."""
+        hf_config = self.model_runner.config.hf_config
+        vision_config = hf_config.vision_config
+        merge_size = vision_config.spatial_merge_size
+
+        image_token_id = getattr(hf_config, "image_token_id", None)
+        vision_start_token_id = getattr(
+            hf_config,
+            "vision_start_token_id",
+            None,
+        )
+        vision_end_token_id = getattr(
+            hf_config,
+            "vision_end_token_id",
+            None,
+        )
+
+        if None in (
+            image_token_id,
+            vision_start_token_id,
+            vision_end_token_id,
+        ):
+            raise ValueError(
+                "Missing vision placeholder token ids in the config"
+            )
+
+        if image_grid_thw.dim() != 2 or image_grid_thw.size(-1) != 3:
+            raise ValueError(
+                "image_grid_thw must have shape [num_images, 3]"
+            )
+
+        grids = image_grid_thw.tolist()
+        expected_counts = [
+            int(t * h * w // (merge_size**2))
+            for t, h, w in grids
+        ]
+
+        new_input_ids: list[int] = []
+        i = 0
+        image_idx = 0
+        total_images = len(expected_counts)
+        length = len(input_ids)
+
+        placeholder_ranges: list[tuple[int, int]] = []
+
+        while i < length:
+            token = input_ids[i]
+            if token == vision_start_token_id and image_idx < total_images:
+                new_input_ids.append(token)
+                i += 1
+                # Skip original contents until matching vision_end_token_id
+                while i < length and input_ids[i] != vision_end_token_id:
+                    i += 1
+                if i == length:
+                    raise ValueError(
+                        "vision_start_token does not have a matching "
+                        "vision_end_token"
+                    )
+
+                required = expected_counts[image_idx]
+                start_offset = len(new_input_ids)
+                new_input_ids.extend([image_token_id] * required)
+                new_input_ids.append(vision_end_token_id)
+                placeholder_ranges.append((start_offset, required))
+                i += 1  # Skip the original vision_end token
+                image_idx += 1
+            else:
+                new_input_ids.append(token)
+                i += 1
+
+        if image_idx != total_images:
+            raise ValueError(
+                f"{total_images - image_idx} images do not have matching "
+                "placeholders"
+            )
+
+        return new_input_ids, expected_counts, placeholder_ranges
 
     def exit(self):
         self.model_runner.call("exit")
@@ -39,18 +126,43 @@ class LLMEngine:
         for p in self.ps:
             p.join()
 
-    def add_request(self, prompt: str | list[int], sampling_params: SamplingParams):
+    def add_request(
+        self,
+        prompt: str | list[int],
+        sampling_params: SamplingParams,
+        images=None,
+        pixel_values=None,
+        image_grid_thw=None,
+        vision_counts=None,
+        vision_placeholders=None,
+    ):
         if isinstance(prompt, str):
             prompt = self.tokenizer.encode(prompt)
-        seq = Sequence(prompt, sampling_params)
+        seq = Sequence(
+            prompt,
+            sampling_params,
+            images=images,
+            pixel_values=pixel_values,
+            image_grid_thw=image_grid_thw,
+            vision_counts=vision_counts,
+            vision_placeholders=vision_placeholders,
+        )
         self.scheduler.add(seq)
 
     def step(self):
         seqs, is_prefill = self.scheduler.schedule()
         token_ids = self.model_runner.call("run", seqs, is_prefill)
         self.scheduler.postprocess(seqs, token_ids)
-        outputs = [(seq.seq_id, seq.completion_token_ids) for seq in seqs if seq.is_finished]
-        num_tokens = sum(len(seq) for seq in seqs) if is_prefill else -len(seqs)
+        outputs = [
+            (seq.seq_id, seq.completion_token_ids)
+            for seq in seqs
+            if seq.is_finished
+        ]
+        num_tokens = (
+            sum(len(seq) for seq in seqs)
+            if is_prefill
+            else -len(seqs)
+        )
         return outputs, num_tokens
 
     def is_finished(self):
@@ -63,7 +175,11 @@ class LLMEngine:
         use_tqdm: bool = True,
     ) -> list[str]:
         if use_tqdm:
-            pbar = tqdm(total=len(prompts), desc="Generating", dynamic_ncols=True)
+            pbar = tqdm(
+                total=len(prompts),
+                desc="Generating",
+                dynamic_ncols=True,
+            )
         if not isinstance(sampling_params, list):
             sampling_params = [sampling_params] * len(prompts)
         for prompt, sp in zip(prompts, sampling_params):
@@ -75,19 +191,170 @@ class LLMEngine:
             output, num_tokens = self.step()
             if use_tqdm:
                 if num_tokens > 0:
-                    prefill_throughput = num_tokens / (perf_counter() - t)
+                    prefill_throughput = (
+                        num_tokens / (perf_counter() - t)
+                    )
                 else:
-                    decode_throughput = -num_tokens / (perf_counter() - t)
-                pbar.set_postfix({
-                    "Prefill": f"{int(prefill_throughput)}tok/s",
-                    "Decode": f"{int(decode_throughput)}tok/s",
-                })
+                    decode_throughput = (
+                        -num_tokens / (perf_counter() - t)
+                    )
+                pbar.set_postfix(
+                    {
+                        "Prefill": f"{int(prefill_throughput)}tok/s",
+                        "Decode": f"{int(decode_throughput)}tok/s",
+                    }
+                )
             for seq_id, token_ids in output:
                 outputs[seq_id] = token_ids
                 if use_tqdm:
                     pbar.update(1)
-        outputs = [outputs[seq_id] for seq_id in sorted(outputs.keys())]
-        outputs = [{"text": self.tokenizer.decode(token_ids), "token_ids": token_ids} for token_ids in outputs]
+        outputs = [
+            outputs[seq_id]
+            for seq_id in sorted(outputs.keys())
+        ]
+        outputs = [
+            {
+                "text": self.tokenizer.decode(token_ids),
+                "token_ids": token_ids,
+            }
+            for token_ids in outputs
+        ]
         if use_tqdm:
             pbar.close()
         return outputs
+
+    def generate_multimodal(
+        self,
+        requests: list[dict],
+        sampling_params: SamplingParams | list[SamplingParams],
+        processor,
+        use_tqdm: bool = True,
+    ) -> list[str]:
+        if use_tqdm:
+            pbar = tqdm(
+                total=len(requests),
+                desc="Generating",
+                dynamic_ncols=True,
+            )
+
+        if not isinstance(sampling_params, list):
+            sampling_params = [sampling_params] * len(requests)
+
+        for request, sp in zip(requests, sampling_params):
+            messages = request.get("messages")
+            text = request.get("text")
+            images = request.get("images")
+
+            if text is None:
+                if messages is None:
+                    raise ValueError(
+                        "multimodal request requires 'text' or 'messages'"
+                    )
+
+                text = processor.apply_chat_template(
+                    messages,
+                    tokenize=False,
+                    add_generation_prompt=True,
+                )
+
+                if images is None:
+                    extracted_images = []
+                    for message in messages:
+                        for content in message.get("content", []):
+                            is_image = content.get("type") == "image"
+                            has_payload = "image" in content
+                            if is_image and has_payload:
+                                extracted_images.append(content["image"])
+                    images = extracted_images if extracted_images else None
+
+            if images is not None and not isinstance(images, (list, tuple)):
+                images = [images]
+
+            processor_kwargs = {
+                "text": [text],
+                "return_tensors": "pt",
+                "padding": True,
+            }
+            if images:
+                # Let the processor handle image normalization + batching.
+                processor_kwargs["images"] = images
+
+            processor_outputs = processor(**processor_kwargs)
+
+            input_ids = processor_outputs["input_ids"][0].tolist()
+            pixel_values = processor_outputs.get("pixel_values")
+            image_grid_thw = processor_outputs.get("image_grid_thw")
+
+            vision_counts = []
+            vision_placeholders = []
+            if image_grid_thw is not None:
+                (
+                    expanded_input_ids,
+                    vision_counts,
+                    vision_placeholders,
+                ) = self._expand_vision_placeholders(
+                    input_ids,
+                    image_grid_thw.squeeze(0)
+                    if image_grid_thw.dim() == 3
+                    else image_grid_thw,
+                )
+                input_ids = expanded_input_ids
+
+            if pixel_values is not None:
+                # Move vision features to CPU; ModelRunner will re-upload.
+                pixel_values = pixel_values.contiguous().cpu()
+
+            if image_grid_thw is not None:
+                image_grid_thw = image_grid_thw.contiguous().cpu()
+
+            self.add_request(
+                input_ids,
+                sp,
+                pixel_values=pixel_values,
+                image_grid_thw=image_grid_thw,
+                vision_counts=vision_counts,
+                vision_placeholders=vision_placeholders,
+            )
+
+        outputs = {}
+        prefill_throughput = decode_throughput = 0.
+        while not self.is_finished():
+            t = perf_counter()
+            output, num_tokens = self.step()
+            if use_tqdm:
+                if num_tokens > 0:
+                    prefill_throughput = num_tokens / (perf_counter() - t)
+                else:
+                    decode_throughput = -num_tokens / (perf_counter() - t)
+                pbar.set_postfix(
+                    {
+                        "Prefill": f"{int(prefill_throughput)}tok/s",
+                        "Decode": f"{int(decode_throughput)}tok/s",
+                    }
+                )
+            for seq_id, token_ids in output:
+                outputs[seq_id] = token_ids
+                if use_tqdm:
+                    pbar.update(1)
+
+        outputs = [
+            outputs[seq_id]
+            for seq_id in sorted(outputs.keys())
+        ]
+        results = [
+            {
+                # Decode without special tokens so the response is clean.
+                "text": self.tokenizer.decode(
+                    token_ids,
+                    skip_special_tokens=True,
+                    clean_up_tokenization_spaces=False,
+                ),
+                "token_ids": token_ids,
+            }
+            for token_ids in outputs
+        ]
+
+        if use_tqdm:
+            pbar.close()
+
+        return results

--- a/nanovllm/engine/model_runner.py
+++ b/nanovllm/engine/model_runner.py
@@ -6,10 +6,18 @@ from multiprocessing.shared_memory import SharedMemory
 
 from nanovllm.config import Config
 from nanovllm.engine.sequence import Sequence
-from nanovllm.models.qwen3 import Qwen3ForCausalLM
 from nanovllm.layers.sampler import Sampler
 from nanovllm.utils.context import set_context, get_context, reset_context
 from nanovllm.utils.loader import load_model
+
+try:
+    from nanovllm.models.qwen3_vl import load_qwen3_vl_model
+    MULTIMODAL_AVAILABLE = True
+except ImportError:
+    MULTIMODAL_AVAILABLE = False
+    print("[ModelRunner] multimodal module unavailable")
+
+from nanovllm.models.qwen3 import Qwen3ForCausalLM
 
 
 class ModelRunner:
@@ -23,13 +31,50 @@ class ModelRunner:
         self.rank = rank
         self.event = event
 
-        dist.init_process_group("nccl", "tcp://localhost:2333", world_size=self.world_size, rank=rank)
+        dist.init_process_group(
+            "nccl",
+            "tcp://localhost:2333",
+            world_size=self.world_size,
+            rank=rank,
+        )
         torch.cuda.set_device(rank)
         default_dtype = torch.get_default_dtype()
-        torch.set_default_dtype(hf_config.torch_dtype)
+        torch_dtype = getattr(hf_config, "torch_dtype", None)
+        if torch_dtype is None and hasattr(hf_config, "text_config"):
+            torch_dtype = getattr(hf_config.text_config, "torch_dtype", None)
+        if isinstance(torch_dtype, str):
+            resolved_dtype = getattr(torch, torch_dtype, None)
+            if resolved_dtype is None:
+                alias_map = {
+                    "bf16": torch.bfloat16,
+                    "fp16": torch.float16,
+                    "float16": torch.float16,
+                }
+                resolved_dtype = alias_map.get(torch_dtype.lower())
+            torch_dtype = resolved_dtype
+        if torch_dtype is None:
+            torch_dtype = torch.float16
+        torch.set_default_dtype(torch_dtype)
         torch.set_default_device("cuda")
-        self.model = Qwen3ForCausalLM(hf_config)
-        load_model(self.model, config.model)
+
+        # Multimodal support is optional; fall back to text-only runner when
+        # the extended Qwen3-VL stack is not available.
+        self.is_multimodal = (
+            getattr(config, "is_multimodal", False) and MULTIMODAL_AVAILABLE
+        )
+        if self.is_multimodal:
+            self.model = load_qwen3_vl_model(config.model, config)
+        else:
+            text_config = getattr(hf_config, "text_config", hf_config)
+            self.model = Qwen3ForCausalLM(text_config)
+            load_model(self.model, config.model)
+
+        embed_module = getattr(self.model, "language_model", self.model)
+        if hasattr(embed_module, "model"):
+            embed_module = embed_module.model
+        # Keep a reference dtype so that cached vision embeddings can be copied
+        # back to the GPU without hitting dtype mismatches.
+        self.model_dtype = embed_module.embed_tokens.weight.dtype
         self.sampler = Sampler()
         self.warmup_model()
         self.allocate_kv_cache()
@@ -40,7 +85,11 @@ class ModelRunner:
 
         if self.world_size > 1:
             if rank == 0:
-                self.shm = SharedMemory(name="nanovllm", create=True, size=2**20)
+                self.shm = SharedMemory(
+                    name="nanovllm",
+                    create=True,
+                    size=2**20,
+                )
                 dist.barrier()
             else:
                 dist.barrier()
@@ -91,8 +140,12 @@ class ModelRunner:
     def warmup_model(self):
         torch.cuda.empty_cache()
         torch.cuda.reset_peak_memory_stats()
-        max_num_batched_tokens, max_model_len = self.config.max_num_batched_tokens, self.config.max_model_len
-        num_seqs = min(max_num_batched_tokens // max_model_len, self.config.max_num_seqs)
+        max_num_batched_tokens = self.config.max_num_batched_tokens
+        max_model_len = self.config.max_model_len
+        num_seqs = min(
+            max_num_batched_tokens // max_model_len,
+            self.config.max_num_seqs,
+        )
         seqs = [Sequence([0] * max_model_len) for _ in range(num_seqs)]
         self.run(seqs, True)
         torch.cuda.empty_cache()
@@ -100,16 +153,47 @@ class ModelRunner:
     def allocate_kv_cache(self):
         config = self.config
         hf_config = config.hf_config
+        text_config = getattr(hf_config, "text_config", hf_config)
         free, total = torch.cuda.mem_get_info()
         used = total - free
         peak = torch.cuda.memory_stats()["allocated_bytes.all.peak"]
         current = torch.cuda.memory_stats()["allocated_bytes.all.current"]
-        num_kv_heads = hf_config.num_key_value_heads // self.world_size
-        head_dim = getattr(hf_config, "head_dim", hf_config.hidden_size // hf_config.num_attention_heads)
-        block_bytes = 2 * hf_config.num_hidden_layers * self.block_size * num_kv_heads * head_dim * hf_config.torch_dtype.itemsize
-        config.num_kvcache_blocks = int(total * config.gpu_memory_utilization - used - peak + current) // block_bytes
+        num_kv_heads = text_config.num_key_value_heads // self.world_size
+        head_dim = getattr(
+            text_config,
+            "head_dim",
+            text_config.hidden_size // text_config.num_attention_heads,
+        )
+        dtype = getattr(
+            text_config,
+            "torch_dtype",
+            getattr(hf_config, "torch_dtype", torch.float16),
+        )
+        if isinstance(dtype, str):
+            dtype = getattr(torch, dtype, torch.float16)
+        block_bytes = (
+            2
+            * text_config.num_hidden_layers
+            * self.block_size
+            * num_kv_heads
+            * head_dim
+            * dtype.itemsize
+        )
+        config.num_kvcache_blocks = (
+            int(total * config.gpu_memory_utilization - used - peak + current)
+            // block_bytes
+        )
         assert config.num_kvcache_blocks > 0
-        self.kv_cache = torch.empty(2, hf_config.num_hidden_layers, config.num_kvcache_blocks, self.block_size, num_kv_heads, head_dim)
+        self.kv_cache = torch.empty(
+            2,
+            text_config.num_hidden_layers,
+            config.num_kvcache_blocks,
+            self.block_size,
+            num_kv_heads,
+            head_dim,
+            dtype=dtype,
+            device="cuda",
+        )
         layer_id = 0
         for module in self.model.modules():
             if hasattr(module, "k_cache") and hasattr(module, "v_cache"):
@@ -119,8 +203,14 @@ class ModelRunner:
 
     def prepare_block_tables(self, seqs: list[Sequence]):
         max_len = max(len(seq.block_table) for seq in seqs)
-        block_tables = [seq.block_table + [-1] * (max_len - len(seq.block_table)) for seq in seqs]
-        block_tables = torch.tensor(block_tables, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
+        block_tables = [
+            seq.block_table + [-1] * (max_len - len(seq.block_table))
+            for seq in seqs
+        ]
+        block_tables = (
+            torch.tensor(block_tables, dtype=torch.int32, pin_memory=True)
+            .cuda(non_blocking=True)
+        )
         return block_tables
 
     def prepare_prefill(self, seqs: list[Sequence]):
@@ -149,16 +239,40 @@ class ModelRunner:
                 if i != seq.num_blocks - 1:
                     end = start + self.block_size
                 else:
-                    end = start + seq.last_block_num_tokens 
+                    end = start + seq.last_block_num_tokens
                 slot_mapping.extend(list(range(start, end)))
         if cu_seqlens_k[-1] > cu_seqlens_q[-1]:    # prefix cache
             block_tables = self.prepare_block_tables(seqs)
-        input_ids = torch.tensor(input_ids, dtype=torch.int64, pin_memory=True).cuda(non_blocking=True)
-        positions = torch.tensor(positions, dtype=torch.int64, pin_memory=True).cuda(non_blocking=True)
-        cu_seqlens_q = torch.tensor(cu_seqlens_q, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
-        cu_seqlens_k = torch.tensor(cu_seqlens_k, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
-        slot_mapping = torch.tensor(slot_mapping, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
-        set_context(True, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k, slot_mapping, None, block_tables)
+        input_ids = (
+            torch.tensor(input_ids, dtype=torch.int64, pin_memory=True)
+            .cuda(non_blocking=True)
+        )
+        positions = (
+            torch.tensor(positions, dtype=torch.int64, pin_memory=True)
+            .cuda(non_blocking=True)
+        )
+        cu_seqlens_q = (
+            torch.tensor(cu_seqlens_q, dtype=torch.int32, pin_memory=True)
+            .cuda(non_blocking=True)
+        )
+        cu_seqlens_k = (
+            torch.tensor(cu_seqlens_k, dtype=torch.int32, pin_memory=True)
+            .cuda(non_blocking=True)
+        )
+        slot_mapping = (
+            torch.tensor(slot_mapping, dtype=torch.int32, pin_memory=True)
+            .cuda(non_blocking=True)
+        )
+        set_context(
+            True,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            max_seqlen_q,
+            max_seqlen_k,
+            slot_mapping,
+            None,
+            block_tables,
+        )
         return input_ids, positions
 
     def prepare_decode(self, seqs: list[Sequence]):
@@ -170,30 +284,70 @@ class ModelRunner:
             input_ids.append(seq.last_token)
             positions.append(len(seq) - 1)
             context_lens.append(len(seq))
-            slot_mapping.append(seq.block_table[-1] * self.block_size + seq.last_block_num_tokens  - 1)
-        input_ids = torch.tensor(input_ids, dtype=torch.int64, pin_memory=True).cuda(non_blocking=True)
-        positions = torch.tensor(positions, dtype=torch.int64, pin_memory=True).cuda(non_blocking=True)
-        slot_mapping = torch.tensor(slot_mapping, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
-        context_lens = torch.tensor(context_lens, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
+            slot_mapping.append(
+                seq.block_table[-1] * self.block_size
+                + seq.last_block_num_tokens
+                - 1
+            )
+        input_ids = (
+            torch.tensor(input_ids, dtype=torch.int64, pin_memory=True)
+            .cuda(non_blocking=True)
+        )
+        positions = (
+            torch.tensor(positions, dtype=torch.int64, pin_memory=True)
+            .cuda(non_blocking=True)
+        )
+        slot_mapping = (
+            torch.tensor(slot_mapping, dtype=torch.int32, pin_memory=True)
+            .cuda(non_blocking=True)
+        )
+        context_lens = (
+            torch.tensor(context_lens, dtype=torch.int32, pin_memory=True)
+            .cuda(non_blocking=True)
+        )
         block_tables = self.prepare_block_tables(seqs)
-        set_context(False, slot_mapping=slot_mapping, context_lens=context_lens, block_tables=block_tables)
+        set_context(
+            False,
+            slot_mapping=slot_mapping,
+            context_lens=context_lens,
+            block_tables=block_tables,
+        )
         return input_ids, positions
 
     def prepare_sample(self, seqs: list[Sequence]):
         temperatures = []
         for seq in seqs:
             temperatures.append(seq.temperature)
-        temperatures = torch.tensor(temperatures, dtype=torch.float32, pin_memory=True).cuda(non_blocking=True)
+        temperatures = (
+            torch.tensor(temperatures, dtype=torch.float32, pin_memory=True)
+            .cuda(non_blocking=True)
+        )
         return temperatures
 
     @torch.inference_mode()
-    def run_model(self, input_ids: torch.Tensor, positions: torch.Tensor, is_prefill: bool):
+    def run_model(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        is_prefill: bool,
+        sequence_lengths: list[int] | None = None,
+        vision_slices_per_seq: list[list[dict]] | None = None,
+    ):
         if is_prefill or self.enforce_eager or input_ids.size(0) > 512:
-            return self.model.compute_logits(self.model(input_ids, positions))
+            model_kwargs = {}
+            if self.is_multimodal:
+                # Prefill can stream only part of the visual tokens. Pass
+                # slice metadata so the forward pass knows which cached chunks
+                # to use.
+                model_kwargs["sequence_lengths"] = sequence_lengths
+                model_kwargs["vision_slices_per_seq"] = vision_slices_per_seq
+            outputs = self.model(input_ids, positions, **model_kwargs)
+            return self.model.compute_logits(outputs)
         else:
             bs = input_ids.size(0)
             context = get_context()
-            graph = self.graphs[next(x for x in self.graph_bs if x >= bs)]
+            graph_idx = next(x for x in self.graph_bs if x >= bs)
+            graph = self.graphs[graph_idx]
             graph_vars = self.graph_vars
             graph_vars["input_ids"][:bs] = input_ids
             graph_vars["positions"][:bs] = positions
@@ -201,15 +355,157 @@ class ModelRunner:
             graph_vars["slot_mapping"][:bs] = context.slot_mapping
             graph_vars["context_lens"].zero_()
             graph_vars["context_lens"][:bs] = context.context_lens
-            graph_vars["block_tables"][:bs, :context.block_tables.size(1)] = context.block_tables
+            graph_vars["block_tables"][:bs, :context.block_tables.size(1)] = (
+                context.block_tables
+            )
             graph.replay()
             return self.model.compute_logits(graph_vars["outputs"][:bs])
 
     def run(self, seqs: list[Sequence], is_prefill: bool) -> list[int]:
-        input_ids, positions = self.prepare_prefill(seqs) if is_prefill else self.prepare_decode(seqs)
+        if is_prefill:
+            input_ids, positions = self.prepare_prefill(seqs)
+        else:
+            input_ids, positions = self.prepare_decode(seqs)
+
+        # Track how many freshly decoded tokens each sequence contributes; the
+        # model uses these lengths to align partial vision slices with text.
+        sequence_lengths = (
+            [len(seq) - seq.num_cached_tokens for seq in seqs]
+            if is_prefill
+            else None
+        )
+        vision_slices_per_seq = None
+
+        if is_prefill and self.is_multimodal:
+            vision_slices_per_seq = []
+            has_slices = False
+
+            for seq in seqs:
+                # Cache the full vision tower output once; subsequent prefill
+                # steps only read the portions still needed for this sequence.
+                self._ensure_vision_cache(seq)
+                slices_for_seq: list[dict] = []
+                window_start = seq.num_cached_tokens
+                window_end = len(seq)
+
+                for placeholder_idx, (offset, length) in enumerate(
+                    seq.vision_placeholders
+                ):
+                    if placeholder_idx >= len(seq.vision_counts):
+                        continue
+                    consumed = seq.vision_consumed[placeholder_idx]
+                    total_len = length
+                    if consumed >= total_len:
+                        continue
+
+                    range_start = offset
+                    range_end = offset + total_len
+
+                    overlap_start = max(range_start, window_start)
+                    overlap_end = min(range_end, window_end)
+                    if overlap_end <= overlap_start:
+                        continue
+
+                    slice_offset = max(consumed, overlap_start - range_start)
+                    remaining = total_len - slice_offset
+                    overlap_available = overlap_end - overlap_start
+                    take = min(remaining, overlap_available)
+                    if take <= 0:
+                        continue
+
+                    target_offset = overlap_start - window_start
+
+                    chunk_tokens = seq.cached_vision_tokens[placeholder_idx]
+                    token_slice = (
+                        chunk_tokens[slice_offset:slice_offset + take]
+                        .to(
+                            device="cuda",
+                            dtype=self.model_dtype,
+                            non_blocking=True,
+                        )
+                        .contiguous()
+                    )
+
+                    deepstack_slice: list[torch.Tensor] | None = None
+                    if seq.cached_deepstack_tokens:
+                        deepstack_slice = []
+                        for layer_tokens in seq.cached_deepstack_tokens:
+                            if placeholder_idx >= len(layer_tokens):
+                                deepstack_slice.append(None)
+                                continue
+                            layer_slice = (
+                                layer_tokens[placeholder_idx][
+                                    slice_offset:slice_offset + take
+                                ]
+                                .to(
+                                    device="cuda",
+                                    dtype=self.model_dtype,
+                                    non_blocking=True,
+                                )
+                                .contiguous()
+                            )
+                            deepstack_slice.append(layer_slice)
+
+                    slices_for_seq.append(
+                        {
+                            "tokens": token_slice,
+                            "deepstack": deepstack_slice,
+                            "length": take,
+                            "target_offset": target_offset,
+                            "placeholder_idx": placeholder_idx,
+                        }
+                    )
+                    has_slices = True
+
+                vision_slices_per_seq.append(slices_for_seq)
+
+            if not has_slices:
+                vision_slices_per_seq = None
+
+        def _advance_vision_offsets():
+            if not is_prefill or not self.is_multimodal:
+                return
+            if vision_slices_per_seq is None:
+                return
+            for seq, slices in zip(seqs, vision_slices_per_seq):
+                for slice_info in slices:
+                    length = slice_info["length"]
+                    placeholder_idx = slice_info["placeholder_idx"]
+                    if placeholder_idx < len(seq.vision_consumed):
+                        span = seq.vision_placeholders[placeholder_idx][1]
+                        seq.vision_consumed[placeholder_idx] += length
+                        seq.vision_consumed[placeholder_idx] = min(
+                            seq.vision_consumed[placeholder_idx],
+                            span,
+                        )
+                if seq.vision_placeholders:
+                    # Once every placeholder has been consumed we can drop the
+                    # cached tensors to release CPU memory.
+                    all_consumed = all(
+                        seq.vision_consumed[idx] >= span
+                        for idx, (_, span) in enumerate(
+                            seq.vision_placeholders
+                        )
+                    )
+                else:
+                    all_consumed = True
+                if all_consumed:
+                    seq.cached_vision_tokens = None
+                    seq.cached_deepstack_tokens = None
+
         temperatures = self.prepare_sample(seqs) if self.rank == 0 else None
-        logits = self.run_model(input_ids, positions, is_prefill)
-        token_ids = self.sampler(logits, temperatures).tolist() if self.rank == 0 else None
+        logits = self.run_model(
+            input_ids,
+            positions,
+            is_prefill,
+            sequence_lengths=sequence_lengths,
+            vision_slices_per_seq=vision_slices_per_seq,
+        )
+        _advance_vision_offsets()
+        if self.rank == 0:
+            token_ids = self.sampler(logits, temperatures).tolist()
+        else:
+            token_ids = None
         reset_context()
         return token_ids
 
@@ -218,7 +514,9 @@ class ModelRunner:
         config = self.config
         hf_config = config.hf_config
         max_bs = min(self.config.max_num_seqs, 512)
-        max_num_blocks = (config.max_model_len + self.block_size - 1) // self.block_size
+        max_num_blocks = (
+            config.max_model_len + self.block_size - 1
+        ) // self.block_size
         input_ids = torch.zeros(max_bs, dtype=torch.int64)
         positions = torch.zeros(max_bs, dtype=torch.int64)
         slot_mapping = torch.zeros(max_bs, dtype=torch.int32)
@@ -231,10 +529,17 @@ class ModelRunner:
 
         for bs in reversed(self.graph_bs):
             graph = torch.cuda.CUDAGraph()
-            set_context(False, slot_mapping=slot_mapping[:bs], context_lens=context_lens[:bs], block_tables=block_tables[:bs])
-            outputs[:bs] = self.model(input_ids[:bs], positions[:bs])    # warmup
+            set_context(
+                False,
+                slot_mapping=slot_mapping[:bs],
+                context_lens=context_lens[:bs],
+                block_tables=block_tables[:bs],
+            )
+            warmup_out = self.model(input_ids[:bs], positions[:bs])
+            outputs[:bs] = warmup_out  # warmup
             with torch.cuda.graph(graph, self.graph_pool):
-                outputs[:bs] = self.model(input_ids[:bs], positions[:bs])    # capture
+                capture_out = self.model(input_ids[:bs], positions[:bs])
+                outputs[:bs] = capture_out  # capture
             if self.graph_pool is None:
                 self.graph_pool = graph.pool()
             self.graphs[bs] = graph
@@ -249,3 +554,39 @@ class ModelRunner:
             block_tables=block_tables,
             outputs=outputs,
         )
+
+    def _ensure_vision_cache(self, seq: Sequence):
+        if seq.cached_vision_tokens is not None:
+            return
+        if seq.pixel_values is None or seq.image_grid_thw is None:
+            seq.cached_vision_tokens = []
+            seq.cached_deepstack_tokens = []
+            return
+
+        # Run the vision encoder once on the GPU and stash the outputs on CPU.
+        # Later prefill iterations reuse these tensors without recomputing the
+        # expensive 3D convolutions.
+        pixel = seq.pixel_values.to(
+            device="cuda",
+            dtype=self.model_dtype,
+            non_blocking=True,
+        ).contiguous()
+        grid = seq.image_grid_thw.to(
+            device="cuda",
+            dtype=torch.int32,
+            non_blocking=True,
+        ).contiguous()
+
+        image_embeds, deepstack_features = self.model.visual(pixel, grid)
+        seq.cached_vision_tokens = [emb.detach().cpu() for emb in image_embeds]
+        if deepstack_features:
+            cached_deepstack = []
+            for layer_tokens in deepstack_features:
+                cached_layer = [feat.detach().cpu() for feat in layer_tokens]
+                cached_deepstack.append(cached_layer)
+            seq.cached_deepstack_tokens = cached_deepstack
+        else:
+            seq.cached_deepstack_tokens = []
+
+        seq.pixel_values = None
+        seq.image_grid_thw = None

--- a/nanovllm/engine/scheduler.py
+++ b/nanovllm/engine/scheduler.py
@@ -11,7 +11,21 @@ class Scheduler:
         self.max_num_seqs = config.max_num_seqs
         self.max_num_batched_tokens = config.max_num_batched_tokens
         self.eos = config.eos
-        self.block_manager = BlockManager(config.num_kvcache_blocks, config.kvcache_block_size)
+        non_cache_token_ids: list[int] = []
+        if config.is_multimodal and config.hf_config is not None:
+            for attr in (
+                "image_token_id",
+                "vision_start_token_id",
+                "vision_end_token_id",
+            ):
+                token_id = getattr(config.hf_config, attr, None)
+                if token_id is not None:
+                    non_cache_token_ids.append(token_id)
+        self.block_manager = BlockManager(
+            config.num_kvcache_blocks,
+            config.kvcache_block_size,
+            non_cache_token_ids=non_cache_token_ids,
+        )
         self.waiting: deque[Sequence] = deque()
         self.running: deque[Sequence] = deque()
 
@@ -28,7 +42,10 @@ class Scheduler:
         num_batched_tokens = 0
         while self.waiting and num_seqs < self.max_num_seqs:
             seq = self.waiting[0]
-            if num_batched_tokens + len(seq) > self.max_num_batched_tokens or not self.block_manager.can_allocate(seq):
+            if (
+                num_batched_tokens + len(seq) > self.max_num_batched_tokens
+                or not self.block_manager.can_allocate(seq)
+            ):
                 break
             num_seqs += 1
             self.block_manager.allocate(seq)
@@ -62,10 +79,16 @@ class Scheduler:
         self.block_manager.deallocate(seq)
         self.waiting.appendleft(seq)
 
-    def postprocess(self, seqs: list[Sequence], token_ids: list[int]) -> list[bool]:
+    def postprocess(
+        self,
+        seqs: list[Sequence],
+        token_ids: list[int],
+    ) -> list[bool]:
         for seq, token_id in zip(seqs, token_ids):
             seq.append_token(token_id)
-            if (not seq.ignore_eos and token_id == self.eos) or seq.num_completion_tokens == seq.max_tokens:
+            reached_eos = not seq.ignore_eos and token_id == self.eos
+            reached_limit = seq.num_completion_tokens == seq.max_tokens
+            if reached_eos or reached_limit:
                 seq.status = SequenceStatus.FINISHED
                 self.block_manager.deallocate(seq)
                 self.running.remove(seq)

--- a/nanovllm/engine/sequence.py
+++ b/nanovllm/engine/sequence.py
@@ -1,6 +1,9 @@
 from copy import copy
 from enum import Enum, auto
 from itertools import count
+from typing import Optional
+
+import torch
 
 from nanovllm.sampling_params import SamplingParams
 
@@ -15,7 +18,16 @@ class Sequence:
     block_size = 256
     counter = count()
 
-    def __init__(self, token_ids: list[int], sampling_params = SamplingParams()):
+    def __init__(
+        self,
+        token_ids: list[int],
+        sampling_params: SamplingParams = SamplingParams(),
+        images=None,
+        pixel_values=None,
+        image_grid_thw=None,
+        vision_counts: Optional[list[int]] = None,
+        vision_placeholders: Optional[list[tuple[int, int]]] = None,
+    ):
         self.seq_id = next(Sequence.counter)
         self.status = SequenceStatus.WAITING
         self.token_ids = copy(token_ids)
@@ -27,6 +39,27 @@ class Sequence:
         self.temperature = sampling_params.temperature
         self.max_tokens = sampling_params.max_tokens
         self.ignore_eos = sampling_params.ignore_eos
+        # Multimodal metadata
+        self.images = images
+        self.pixel_values = pixel_values
+        self.image_grid_thw = image_grid_thw
+        self.vision_placeholders = vision_placeholders or []
+        if vision_counts is not None:
+            self.vision_counts = vision_counts
+        elif self.vision_placeholders:
+            self.vision_counts = [
+                length for _, length in self.vision_placeholders
+            ]
+        else:
+            self.vision_counts = []
+        # Track how many visual tokens per placeholder have been copied into
+        # the prompt so far.
+        self.vision_consumed = [0] * len(self.vision_placeholders)
+        # Cached outputs of the vision encoder; populated on first access and
+        # released once every placeholder is consumed.
+        self.cached_vision_tokens: Optional[list[torch.Tensor]] = None
+        self.cached_deepstack_tokens: Optional[list[list[torch.Tensor]]] = None
+        self.vision_offset = 0
 
     def __len__(self):
         return self.num_tokens
@@ -72,12 +105,34 @@ class Sequence:
         self.num_tokens += 1
 
     def __getstate__(self):
-        return (self.num_tokens, self.num_prompt_tokens, self.num_cached_tokens, self.block_table,
-                self.token_ids if self.num_completion_tokens == 0 else self.last_token)
+        return (
+            self.num_tokens,
+            self.num_prompt_tokens,
+            self.num_cached_tokens,
+            self.block_table,
+            self.token_ids
+            if self.num_completion_tokens == 0
+            else self.last_token,
+        )
 
     def __setstate__(self, state):
-        self.num_tokens, self.num_prompt_tokens, self.num_cached_tokens, self.block_table = state[:-1]
+        (
+            self.num_tokens,
+            self.num_prompt_tokens,
+            self.num_cached_tokens,
+            self.block_table,
+        ) = state[:-1]
         if self.num_completion_tokens == 0:
             self.token_ids = state[-1]
         else:
             self.last_token = state[-1]
+        # Reset multimodal caches when the sequence is restored.
+        self.images = None
+        self.pixel_values = None
+        self.image_grid_thw = None
+        self.vision_placeholders = []
+        self.vision_counts = []
+        self.vision_consumed = []
+        self.cached_vision_tokens = None
+        self.cached_deepstack_tokens = None
+        self.vision_offset = 0

--- a/nanovllm/models/qwen3_vl.py
+++ b/nanovllm/models/qwen3_vl.py
@@ -1,0 +1,1049 @@
+"""Simplified implementation of the Qwen3-VL multimodal model.
+
+This module inlines both the text backbone and the vision encoder to minimise
+changes to other components.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import List, Optional, Sequence, Tuple
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import nn
+
+from nanovllm.layers.activation import SiluAndMul
+from nanovllm.layers.attention import Attention
+from nanovllm.layers.embed_head import ParallelLMHead, VocabParallelEmbedding
+from nanovllm.layers.layernorm import RMSNorm
+from nanovllm.layers.linear import (
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+)
+from nanovllm.layers.rotary_embedding import get_rope
+
+
+# ---------------------------------------------------------------------------
+# Text backbone (supports DeepStack injection)
+# ---------------------------------------------------------------------------
+
+
+class Qwen3VLTextAttention(nn.Module):
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        max_position: int,
+        rms_norm_eps: float,
+        qkv_bias: bool,
+        head_dim: int | None,
+        rope_theta: float,
+        rope_scaling: tuple | None,
+    ) -> None:
+        super().__init__()
+        tp_size = dist.get_world_size()
+        self.total_num_heads = num_heads
+        assert self.total_num_heads % tp_size == 0
+        self.num_heads = self.total_num_heads // tp_size
+        self.total_num_kv_heads = num_kv_heads
+        assert self.total_num_kv_heads % tp_size == 0
+        self.num_kv_heads = self.total_num_kv_heads // tp_size
+        self.head_dim = head_dim or hidden_size // self.total_num_heads
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.scaling = self.head_dim ** -0.5
+        self.qkv_bias = qkv_bias
+
+        self.qkv_proj = QKVParallelLinear(
+            hidden_size,
+            self.head_dim,
+            self.total_num_heads,
+            self.total_num_kv_heads,
+            bias=qkv_bias,
+        )
+        self.o_proj = RowParallelLinear(
+            self.total_num_heads * self.head_dim,
+            hidden_size,
+            bias=False,
+        )
+        self.rotary_emb = get_rope(
+            self.head_dim,
+            rotary_dim=self.head_dim,
+            max_position=max_position,
+            base=rope_theta,
+            rope_scaling=rope_scaling,
+        )
+        self.attn = Attention(
+            self.num_heads,
+            self.head_dim,
+            self.scaling,
+            self.num_kv_heads,
+        )
+        if not self.qkv_bias:
+            self.q_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
+            self.k_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        qkv = self.qkv_proj(hidden_states)
+        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        q = q.view(-1, self.num_heads, self.head_dim)
+        k = k.view(-1, self.num_kv_heads, self.head_dim)
+        v = v.view(-1, self.num_kv_heads, self.head_dim)
+        if not self.qkv_bias:
+            q = self.q_norm(q)
+            k = self.k_norm(k)
+        q, k = self.rotary_emb(positions, q, k)
+        o = self.attn(q, k, v)
+        output = self.o_proj(o.flatten(1, -1))
+        return output
+
+
+class Qwen3VLTextMLP(nn.Module):
+
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        hidden_act: str,
+    ) -> None:
+        super().__init__()
+        self.gate_up_proj = MergedColumnParallelLinear(
+            hidden_size,
+            [intermediate_size] * 2,
+            bias=False,
+        )
+        self.down_proj = RowParallelLinear(
+            intermediate_size,
+            hidden_size,
+            bias=False,
+        )
+        assert hidden_act == "silu"
+        self.act_fn = SiluAndMul()
+
+    def forward(self, x):
+        gate_up = self.gate_up_proj(x)
+        x = self.act_fn(gate_up)
+        x = self.down_proj(x)
+        return x
+
+
+class Qwen3VLTextDecoderLayer(nn.Module):
+
+    def __init__(
+        self,
+        config,
+    ) -> None:
+        super().__init__()
+        rope_scaling = getattr(config, "rope_scaling", None)
+        if isinstance(rope_scaling, dict):
+            rope_scaling = None
+
+        self.self_attn = Qwen3VLTextAttention(
+            hidden_size=config.hidden_size,
+            num_heads=config.num_attention_heads,
+            num_kv_heads=config.num_key_value_heads,
+            max_position=config.max_position_embeddings,
+            rms_norm_eps=config.rms_norm_eps,
+            qkv_bias=getattr(config, "attention_bias", True),
+            head_dim=getattr(config, "head_dim", None),
+            rope_theta=getattr(config, "rope_theta", 1000000),
+            rope_scaling=rope_scaling,
+        )
+        self.mlp = Qwen3VLTextMLP(
+            hidden_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+            hidden_act=config.hidden_act,
+        )
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if residual is None:
+            hidden_states, residual = self.input_layernorm(hidden_states), hidden_states
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+        hidden_states = self.self_attn(positions, hidden_states)
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states = self.mlp(hidden_states)
+        return hidden_states, residual
+
+
+class Qwen3VLTextModel(nn.Module):
+
+    def __init__(
+        self,
+        config,
+    ) -> None:
+        super().__init__()
+        self.embed_tokens = VocabParallelEmbedding(config.vocab_size, config.hidden_size)
+        self.layers = nn.ModuleList(
+            [Qwen3VLTextDecoderLayer(config) for _ in range(config.num_hidden_layers)]
+        )
+        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        positions: torch.Tensor | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        vision_token_count: int | None = None,
+        visual_pos_mask: torch.Tensor | None = None,
+        deepstack_visual_embeds: list[torch.Tensor] | None = None,
+    ) -> torch.Tensor:
+        if inputs_embeds is not None:
+            hidden_states = inputs_embeds
+        else:
+            hidden_states = self.embed_tokens(input_ids)
+
+        residual = None
+        if visual_pos_mask is not None:
+            visual_pos_mask = visual_pos_mask.to(hidden_states.device)
+        mask_tensor = None
+        for layer_idx, layer in enumerate(self.layers):
+            hidden_states, residual = layer(positions, hidden_states, residual)
+            if (
+                deepstack_visual_embeds is not None
+                and vision_token_count is not None
+                and layer_idx < len(deepstack_visual_embeds)
+            ):
+                ds = deepstack_visual_embeds[layer_idx].to(
+                    hidden_states.device, hidden_states.dtype
+                )
+                hidden_states = hidden_states.clone()
+                if visual_pos_mask is not None:
+                    if mask_tensor is None:
+                        mask_tensor = visual_pos_mask.bool()
+                    if mask_tensor.sum().item() != ds.size(0):
+                        raise ValueError("DeepStack features do not match the visual mask length")
+                    hidden_states[mask_tensor] += ds
+                else:
+                    hidden_states[:vision_token_count] += ds
+        hidden_states, _ = self.norm(hidden_states, residual)
+        return hidden_states
+
+
+class Qwen3VLTextForCausalLM(nn.Module):
+    packed_modules_mapping = {
+        "q_proj": ("qkv_proj", "q"),
+        "k_proj": ("qkv_proj", "k"),
+        "v_proj": ("qkv_proj", "v"),
+        "gate_proj": ("gate_up_proj", 0),
+        "up_proj": ("gate_up_proj", 1),
+    }
+
+    def __init__(self, config) -> None:
+        super().__init__()
+        self.model = Qwen3VLTextModel(config)
+        self.lm_head = ParallelLMHead(config.vocab_size, config.hidden_size)
+        if config.tie_word_embeddings:
+            self.lm_head.weight.data = self.model.embed_tokens.weight.data
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        positions: torch.Tensor | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        vision_token_count: int | None = None,
+        visual_pos_mask: torch.Tensor | None = None,
+        deepstack_visual_embeds: list[torch.Tensor] | None = None,
+        **_: dict,
+    ) -> torch.Tensor:
+        return self.model(
+            input_ids,
+            positions,
+            inputs_embeds=inputs_embeds,
+            vision_token_count=vision_token_count,
+            visual_pos_mask=visual_pos_mask,
+            deepstack_visual_embeds=deepstack_visual_embeds,
+        )
+
+    def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.lm_head(hidden_states)
+
+
+# ---------------------------------------------------------------------------
+# Vision encoder (vision tower + DeepStack features)
+# ---------------------------------------------------------------------------
+
+
+def gelu_pytorch_tanh(x: torch.Tensor) -> torch.Tensor:
+    inner = math.sqrt(2 / math.pi) * (x + 0.044715 * x * x * x)
+    return 0.5 * x * (1 + torch.tanh(inner))
+
+
+def rotate_half(x: torch.Tensor) -> torch.Tensor:
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb_vision(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    cos = cos.unsqueeze(0).to(q.dtype)
+    sin = sin.unsqueeze(0).to(q.dtype)
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+class Qwen3VLVisionPatchEmbed(nn.Module):
+    def __init__(self, config) -> None:
+        super().__init__()
+        self.patch_size = config.patch_size
+        self.temporal_patch_size = getattr(config, "temporal_patch_size", 1)
+        self.in_channels = config.in_channels
+        self.embed_dim = config.hidden_size
+
+        kernel_size = [
+            self.temporal_patch_size,
+            self.patch_size,
+            self.patch_size,
+        ]
+        stride = kernel_size
+        self.proj = nn.Conv3d(
+            self.in_channels,
+            self.embed_dim,
+            kernel_size=kernel_size,
+            stride=stride,
+            bias=True,
+        )
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        if inputs.dim() == 4:
+            inputs = inputs.unsqueeze(2)
+        hidden_states = self.proj(inputs)
+        hidden_states = hidden_states.flatten(2).transpose(1, 2)
+        return hidden_states
+
+
+class Qwen3VLVisionRotaryEmbedding(nn.Module):
+    inv_freq: torch.Tensor
+
+    def __init__(self, dim: int, theta: float = 10000.0) -> None:
+        super().__init__()
+        inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2, dtype=torch.float) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    def forward(self, seqlen: int) -> torch.Tensor:
+        seq = torch.arange(seqlen, device=self.inv_freq.device, dtype=self.inv_freq.dtype)
+        freqs = torch.outer(seq, self.inv_freq)
+        return freqs
+
+
+class Qwen3VLVisionMLP(nn.Module):
+    def __init__(self, config) -> None:
+        super().__init__()
+        self.linear_fc1 = nn.Linear(config.hidden_size, config.intermediate_size, bias=True)
+        self.linear_fc2 = nn.Linear(config.intermediate_size, config.hidden_size, bias=True)
+        if getattr(config, "hidden_act", "gelu") == "gelu_pytorch_tanh":
+            self.act_fn = gelu_pytorch_tanh
+        else:
+            self.act_fn = lambda x: F.gelu(x, approximate="tanh")
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.linear_fc1(hidden_states)
+        hidden_states = self.act_fn(hidden_states)
+        hidden_states = self.linear_fc2(hidden_states)
+        return hidden_states
+
+
+class Qwen3VLVisionAttention(nn.Module):
+    def __init__(self, config) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_heads
+        self.head_dim = self.hidden_size // self.num_heads
+        self.scale = self.head_dim**-0.5
+
+        self.qkv = nn.Linear(self.hidden_size, self.hidden_size * 3, bias=True)
+        self.proj = nn.Linear(self.hidden_size, self.hidden_size, bias=True)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        seq_lengths: Sequence[int],
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        outputs = []
+        offset = 0
+        cos, sin = position_embeddings
+        for length in seq_lengths:
+            chunk = hidden_states[offset : offset + length]
+            cos_chunk = cos[offset : offset + length]
+            sin_chunk = sin[offset : offset + length]
+
+            qkv = self.qkv(chunk)
+            q, k, v = qkv.chunk(3, dim=-1)
+
+            q = q.view(length, self.num_heads, self.head_dim).transpose(0, 1)
+            k = k.view(length, self.num_heads, self.head_dim).transpose(0, 1)
+            v = v.view(length, self.num_heads, self.head_dim).transpose(0, 1)
+
+            q, k = apply_rotary_pos_emb_vision(q, k, cos_chunk, sin_chunk)
+            if q.dtype != v.dtype:
+                q = q.to(v.dtype)
+                k = k.to(v.dtype)
+
+            attn_scores = torch.matmul(q, k.transpose(-1, -2)) * self.scale
+            attn_weights = torch.softmax(attn_scores, dim=-1, dtype=torch.float32).to(v.dtype)
+            attn_output = torch.matmul(attn_weights, v)
+
+            attn_output = attn_output.transpose(0, 1).reshape(length, self.hidden_size)
+            attn_output = self.proj(attn_output)
+            outputs.append(attn_output)
+            offset += length
+
+        return torch.cat(outputs, dim=0)
+
+
+class Qwen3VLVisionPatchMerger(nn.Module):
+    def __init__(self, config, use_postshuffle_norm: bool = False) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size * (config.spatial_merge_size**2)
+        self.use_postshuffle_norm = use_postshuffle_norm
+        norm_dim = self.hidden_size if use_postshuffle_norm else config.hidden_size
+        self.norm = nn.LayerNorm(norm_dim, eps=1e-6)
+        self.linear_fc1 = nn.Linear(self.hidden_size, self.hidden_size, bias=True)
+        self.linear_fc2 = nn.Linear(self.hidden_size, config.out_hidden_size, bias=True)
+        self.act_fn = nn.GELU()
+        self.merge_size = config.spatial_merge_size
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        if self.use_postshuffle_norm:
+            hidden_states = hidden_states.view(-1, self.hidden_size)
+        hidden_states = self.norm(hidden_states)
+        hidden_states = hidden_states.view(-1, self.hidden_size)
+        hidden_states = self.linear_fc1(hidden_states)
+        hidden_states = self.act_fn(hidden_states)
+        hidden_states = self.linear_fc2(hidden_states)
+        return hidden_states
+
+
+class Qwen3VLVisionBlock(nn.Module):
+    def __init__(self, config) -> None:
+        super().__init__()
+        self.norm1 = nn.LayerNorm(config.hidden_size, eps=1e-6)
+        self.attn = Qwen3VLVisionAttention(config)
+        self.norm2 = nn.LayerNorm(config.hidden_size, eps=1e-6)
+        self.mlp = Qwen3VLVisionMLP(config)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        seq_lengths: Sequence[int],
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.norm1(hidden_states)
+        hidden_states = residual + self.attn(hidden_states, seq_lengths, position_embeddings)
+        residual = hidden_states
+        hidden_states = self.norm2(hidden_states)
+        hidden_states = residual + self.mlp(hidden_states)
+        return hidden_states
+
+
+class Qwen3VLVisionModel(nn.Module):
+    def __init__(self, config) -> None:
+        super().__init__()
+        self.config = config
+        self.spatial_merge_size = config.spatial_merge_size
+        self.patch_embed = Qwen3VLVisionPatchEmbed(config)
+        self.hidden_size = config.hidden_size
+        self.pos_embed = nn.Embedding(config.num_position_embeddings, config.hidden_size)
+        self.num_grid_per_side = int(config.num_position_embeddings**0.5)
+
+        head_dim = config.hidden_size // config.num_heads
+        self.rotary_pos_emb = Qwen3VLVisionRotaryEmbedding(head_dim // 2)
+
+        self.blocks = nn.ModuleList([Qwen3VLVisionBlock(config) for _ in range(config.depth)])
+        self.merger = Qwen3VLVisionPatchMerger(config=config, use_postshuffle_norm=False)
+
+        self.deepstack_visual_indexes = config.deepstack_visual_indexes
+        self.deepstack_merger_list = nn.ModuleList(
+            [
+                Qwen3VLVisionPatchMerger(
+                    config=config,
+                    use_postshuffle_norm=True,
+                )
+                for _ in range(len(config.deepstack_visual_indexes))
+            ]
+        )
+
+    def rot_pos_emb(self, grid_thw: torch.Tensor) -> torch.Tensor:
+        merge_size = self.spatial_merge_size
+        max_hw = int(grid_thw[:, 1:].max().item())
+        freq_table = self.rotary_pos_emb(max_hw)
+        device = freq_table.device
+
+        total_tokens = int(torch.prod(grid_thw, dim=1).sum().item())
+        pos_ids = torch.empty((total_tokens, 2), dtype=torch.long, device=device)
+
+        offset = 0
+        for num_frames, height, width in grid_thw:
+            merged_h = height // merge_size
+            merged_w = width // merge_size
+            block_rows = torch.arange(merged_h, device=device)
+            block_cols = torch.arange(merged_w, device=device)
+            intra_row = torch.arange(merge_size, device=device)
+            intra_col = torch.arange(merge_size, device=device)
+
+            row_idx = (
+                block_rows[:, None, None, None] * merge_size
+                + intra_row.view(1, 1, -1, 1)
+            )
+            col_idx = (
+                block_cols[None, :, None, None] * merge_size
+                + intra_col.view(1, 1, 1, -1)
+            )
+
+            row_idx = row_idx.expand(merged_h, merged_w, merge_size, merge_size).reshape(-1)
+            col_idx = col_idx.expand(merged_h, merged_w, merge_size, merge_size).reshape(-1)
+
+            coords = torch.stack((row_idx, col_idx), dim=-1)
+
+            if num_frames > 1:
+                coords = coords.repeat(num_frames, 1)
+
+            num_tokens = coords.shape[0]
+            pos_ids[offset: offset + num_tokens] = coords
+            offset += num_tokens
+
+        embeddings = freq_table[pos_ids]
+        embeddings = embeddings.flatten(1)
+        return embeddings
+
+    def fast_pos_embed_interpolate(self, grid_thw: torch.Tensor) -> torch.Tensor:
+        grid_ts, grid_hs, grid_ws = grid_thw[:, 0], grid_thw[:, 1], grid_thw[:, 2]
+        device = grid_thw.device
+
+        idx_list = [[] for _ in range(4)]
+        weight_list = [[] for _ in range(4)]
+
+        for t, h, w in zip(grid_ts, grid_hs, grid_ws):
+            h_idxs = torch.linspace(0, self.num_grid_per_side - 1, h, device=device)
+            w_idxs = torch.linspace(0, self.num_grid_per_side - 1, w, device=device)
+
+            h_floor = h_idxs.long()
+            w_floor = w_idxs.long()
+            h_ceil = (h_floor + 1).clip(max=self.num_grid_per_side - 1)
+            w_ceil = (w_floor + 1).clip(max=self.num_grid_per_side - 1)
+
+            dh = h_idxs - h_floor
+            dw = w_idxs - w_floor
+
+            base_h = h_floor * self.num_grid_per_side
+            base_h_ceil = h_ceil * self.num_grid_per_side
+
+            indices = [
+                (base_h[None].T + w_floor[None]).flatten(),
+                (base_h[None].T + w_ceil[None]).flatten(),
+                (base_h_ceil[None].T + w_floor[None]).flatten(),
+                (base_h_ceil[None].T + w_ceil[None]).flatten(),
+            ]
+
+            weights = [
+                ((1 - dh)[None].T * (1 - dw)[None]).flatten(),
+                ((1 - dh)[None].T * dw[None]).flatten(),
+                (dh[None].T * (1 - dw)[None]).flatten(),
+                (dh[None].T * dw[None]).flatten(),
+            ]
+
+            for i in range(4):
+                idx_list[i].extend(indices[i].tolist())
+                weight_list[i].extend(weights[i].tolist())
+
+        idx_tensor = torch.tensor(idx_list, dtype=torch.long, device=device)
+        weight_tensor = torch.tensor(weight_list, dtype=self.pos_embed.weight.dtype, device=device)
+        pos_embeds = self.pos_embed(idx_tensor) * weight_tensor[:, :, None]
+        patch_pos_embeds = pos_embeds.sum(dim=0)
+
+        patch_pos_embeds = patch_pos_embeds.split([h * w for h, w in zip(grid_hs, grid_ws)])
+
+        patch_pos_embeds_permute = []
+        merge_size = self.config.spatial_merge_size
+        for pos_embed, t, h, w in zip(patch_pos_embeds, grid_ts, grid_hs, grid_ws):
+            pos_embed = pos_embed.repeat(int(t.item()), 1)
+            pos_embed = (
+                pos_embed.view(int(t.item()), h // merge_size, merge_size, w // merge_size, merge_size, -1)
+                .permute(0, 1, 3, 2, 4, 5)
+                .flatten(0, 4)
+            )
+            patch_pos_embeds_permute.append(pos_embed)
+        patch_pos_embeds = torch.cat(patch_pos_embeds_permute)
+        return patch_pos_embeds
+
+    def forward(self, pixel_values: torch.Tensor, grid_thw: torch.Tensor) -> Tuple[torch.Tensor, List[torch.Tensor]]:
+        pixel_values = pixel_values.to(self.pos_embed.weight.dtype)
+        seq_tokens = self.patch_embed(pixel_values)
+        hidden_states = seq_tokens.reshape(-1, self.hidden_size)
+
+        pos_embeds = self.fast_pos_embed_interpolate(grid_thw)
+        hidden_states = hidden_states + pos_embeds
+
+        rotary_pos_emb = self.rot_pos_emb(grid_thw)
+        rotary_pos_emb = rotary_pos_emb.reshape(hidden_states.size(0), -1)
+        emb = torch.cat((rotary_pos_emb, rotary_pos_emb), dim=-1)
+        position_embeddings = (emb.cos(), emb.sin())
+
+        seq_lengths = (grid_thw[:, 0] * grid_thw[:, 1] * grid_thw[:, 2]).tolist()
+
+        deepstack_feature_lists: List[torch.Tensor] = []
+        for layer_idx, block in enumerate(self.blocks):
+            hidden_states = block(hidden_states, seq_lengths, position_embeddings)
+            if layer_idx in self.deepstack_visual_indexes:
+                merger = self.deepstack_merger_list[self.deepstack_visual_indexes.index(layer_idx)]
+                deepstack_feature = merger(hidden_states)
+                deepstack_feature_lists.append(deepstack_feature)
+
+        hidden_states = self.merger(hidden_states)
+        return hidden_states, deepstack_feature_lists
+
+
+class Qwen3VisionEncoder(nn.Module):
+    def __init__(self, vision_config) -> None:
+        super().__init__()
+        self.config = vision_config
+        self.vision = Qwen3VLVisionModel(vision_config)
+
+    def _linear_patch_embed(self, patch_tokens: torch.Tensor) -> torch.Tensor:
+        proj = self.vision.patch_embed.proj
+        weight = proj.weight.view(proj.out_channels, -1)
+        bias = proj.bias
+        return torch.nn.functional.linear(patch_tokens, weight, bias)
+
+    def _run_vision_from_tokens(
+        self,
+        token_list: list[torch.Tensor],
+        grid_thw: torch.Tensor,
+    ) -> Tuple[torch.Tensor, List[torch.Tensor]]:
+        proj = self.vision.patch_embed.proj
+        device = proj.weight.device
+        dtype = proj.weight.dtype
+
+        tokens = torch.cat([t.to(device=device, dtype=dtype) for t in token_list], dim=0)
+        grids = grid_thw.to(device=device, dtype=torch.int32)
+
+        hidden_states = tokens
+
+        pos_embeds = self.vision.fast_pos_embed_interpolate(grids).to(hidden_states.dtype)
+        hidden_states = hidden_states + pos_embeds
+
+        rotary_pos_emb = self.vision.rot_pos_emb(grids).to(hidden_states.dtype)
+        rotary_pos_emb = rotary_pos_emb.reshape(hidden_states.size(0), -1)
+        emb = torch.cat((rotary_pos_emb, rotary_pos_emb), dim=-1)
+        position_embeddings = (emb.cos(), emb.sin())
+
+        seq_lengths = (grids[:, 0] * grids[:, 1] * grids[:, 2]).tolist()
+
+        deepstack_feature_lists: List[torch.Tensor] = []
+        for layer_idx, block in enumerate(self.vision.blocks):
+            hidden_states = block(hidden_states, seq_lengths, position_embeddings)
+            if layer_idx in self.vision.deepstack_visual_indexes:
+                merger = self.vision.deepstack_merger_list[
+                    self.vision.deepstack_visual_indexes.index(layer_idx)
+                ]
+                deepstack_feature = merger(hidden_states)
+                deepstack_feature_lists.append(deepstack_feature)
+
+        hidden_states = self.vision.merger(hidden_states)
+
+        split_sizes = (
+            grids.prod(-1) // (self.config.spatial_merge_size**2)
+        ).tolist()
+
+        image_chunks = list(torch.split(hidden_states, split_sizes))
+
+        deepstack_layers: List[List[torch.Tensor]] = []
+        for feature in deepstack_feature_lists:
+            per_batch = torch.split(feature, split_sizes)
+            deepstack_layers.append(list(per_batch))
+
+        return image_chunks, deepstack_layers
+
+    def _normalize_pixel_inputs(
+        self,
+        pixel_values: torch.Tensor,
+    ) -> Tuple[torch.Tensor, int, int, int, int]:
+        in_channels = getattr(self.config, "in_channels", 3)
+        num_dims = pixel_values.dim()
+
+        channel_axis = None
+        for axis in range(1, num_dims - 2):
+            if pixel_values.shape[axis] == in_channels:
+                channel_axis = axis
+                break
+        if channel_axis is None:
+            channel_axis = 1
+
+        permute_order = [0, channel_axis]
+        temporal_axes = [
+            axis for axis in range(1, num_dims - 2) if axis != channel_axis
+        ]
+        permute_order.extend(temporal_axes)
+        permute_order.extend([num_dims - 2, num_dims - 1])
+
+        pixel_values = pixel_values.permute(*permute_order).contiguous()
+
+        batch = pixel_values.shape[0]
+        channels = pixel_values.shape[1]
+        height = pixel_values.shape[-2]
+        width = pixel_values.shape[-1]
+
+        temporal = int(math.prod(pixel_values.shape[2:-2]))
+        pixel_values = pixel_values.reshape(
+            batch,
+            channels,
+            temporal,
+            height,
+            width,
+        )
+
+        return pixel_values, batch, temporal, height, width
+
+    def forward(
+        self,
+        pixel_values: torch.Tensor,
+        image_grid_thw: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, List[torch.Tensor]]:
+        if pixel_values.dim() <= 3:
+            if image_grid_thw is None:
+                raise ValueError("image_grid_thw is required for flattened inputs")
+            grids = image_grid_thw.to(pixel_values.device).to(torch.int64)
+            tokens_per_image = grids.prod(-1).tolist()
+            if pixel_values.dim() == 3:
+                batch, tokens, feature = pixel_values.shape
+                flat = pixel_values.reshape(batch * tokens, feature)
+            else:
+                flat = pixel_values
+
+            splits = torch.split(flat, tokens_per_image, dim=0)
+            token_list = [self._linear_patch_embed(chunk) for chunk in splits]
+
+            return self._run_vision_from_tokens(token_list, grids)
+
+        pixel_values, batch, temporal, height, width = self._normalize_pixel_inputs(
+            pixel_values
+        )
+
+        if image_grid_thw is None:
+            grid = torch.tensor(
+                [
+                    [
+                        temporal,
+                        height // self.config.patch_size,
+                        width // self.config.patch_size,
+                    ]
+                ]
+                * batch,
+                device=pixel_values.device,
+                dtype=torch.int32,
+            )
+            image_grid_thw = grid
+        else:
+            if image_grid_thw.dim() == 1:
+                image_grid_thw = image_grid_thw.unsqueeze(0)
+            image_grid_thw = image_grid_thw.to(device=pixel_values.device, dtype=torch.int32)
+
+        image_embeds, deepstack = self.vision(pixel_values, image_grid_thw)
+        split_sizes = (
+            image_grid_thw.prod(-1) // (self.config.spatial_merge_size**2)
+        ).tolist()
+
+        image_chunks = torch.split(image_embeds, split_sizes)
+        image_tokens = torch.stack(list(image_chunks), dim=0)
+
+        deepstack_layers: List[torch.Tensor] = []
+        for feature in deepstack:
+            per_batch = torch.split(feature, split_sizes)
+            stacked = torch.stack(list(per_batch), dim=0)
+            deepstack_layers.append(stacked)
+
+        return image_tokens, deepstack_layers
+
+
+def create_vision_model(config, **kwargs) -> nn.Module:
+    del kwargs
+    return Qwen3VisionEncoder(config)
+
+
+def get_vision_model(config, **kwargs) -> nn.Module:
+    return create_vision_model(config, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Multimodal wrapper
+# ---------------------------------------------------------------------------
+
+
+class Qwen3VLForConditionalGeneration(nn.Module):
+    """Qwen3-VL conditional generation model (language + vision)."""
+    
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.text_config = getattr(config, "text_config", config)
+        self.vision_config = getattr(config, "vision_config", None)
+
+        if self.vision_config is None:
+            raise ValueError("vision_config is missing; cannot build a multimodal model")
+
+        self.visual = create_vision_model(self.vision_config)
+        self.language_model = Qwen3VLTextForCausalLM(self.text_config)
+
+        print("[Qwen3VLForConditionalGeneration] Initialization complete")
+        print(f"  - Vision encoder: {type(self.visual).__name__}")
+        print(f"  - Language model: {type(self.language_model).__name__}")
+    
+        self.packed_modules_mapping = {
+            "mlp.gate_proj": ("mlp.gate_up_proj", 0),
+            "mlp.up_proj": ("mlp.gate_up_proj", 1),
+            "q_proj": ("qkv_proj", "q"),
+            "k_proj": ("qkv_proj", "k"),
+            "v_proj": ("qkv_proj", "v"),
+        }
+    
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.language_model.model.embed_tokens(input_ids)
+    
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor | None,
+        inputs_embeds: torch.Tensor | None = None,
+        pixel_values: torch.Tensor | None = None,
+        image_grid_thw: torch.Tensor | None = None,
+        sequence_lengths: list[int] | None = None,
+        vision_slices_per_seq: list[list[dict]] | None = None,
+    ) -> torch.Tensor:
+        if inputs_embeds is None:
+            if input_ids is None:
+                raise ValueError("input_ids and inputs_embeds cannot be None simultaneously")
+            inputs_embeds = self.get_input_embeddings(input_ids)
+
+        total_tokens = inputs_embeds.size(0)
+        inputs_embeds = inputs_embeds.clone()
+
+        visual_pos_mask = torch.zeros(
+            total_tokens, dtype=torch.bool, device=inputs_embeds.device
+        )
+        deepstack_layers: list[torch.Tensor] | None = None
+        vision_token_count = 0
+
+        if vision_slices_per_seq:
+            if sequence_lengths is None:
+                raise ValueError("sequence_lengths must be provided to align visual features")
+            if len(sequence_lengths) != len(vision_slices_per_seq):
+                raise ValueError("sequence_lengths and vision_slices_per_seq have different lengths")
+            if sum(sequence_lengths) != total_tokens:
+                raise ValueError("sum of sequence_lengths does not match total input tokens")
+
+            offsets = [0]
+            for length in sequence_lengths:
+                offsets.append(offsets[-1] + length)
+
+            deepstack_collect: list[list[torch.Tensor]] | None = None
+
+            for seq_idx, (start, end) in enumerate(zip(offsets[:-1], offsets[1:])):
+                seq_slices = vision_slices_per_seq[seq_idx]
+                if not seq_slices:
+                    continue
+
+                for slice_info in seq_slices:
+                    token_slice = slice_info["tokens"].to(
+                        device=inputs_embeds.device,
+                        dtype=inputs_embeds.dtype,
+                    )
+                    length = slice_info["length"]
+                    target_offset = slice_info["target_offset"]
+
+                    if token_slice.size(0) != length:
+                        raise ValueError("Visual token slice length does not match the declared length")
+
+                    target_start = start + target_offset
+                    target_end = target_start + length
+                    if target_end > end:
+                        raise ValueError("Visual token target range is out of bounds")
+
+                    inputs_embeds[target_start:target_end] = token_slice
+                    visual_pos_mask[target_start:target_end] = True
+                    vision_token_count += length
+
+                    deepstack_slice = slice_info.get("deepstack")
+                    if deepstack_slice:
+                        if deepstack_collect is None:
+                            deepstack_collect = [[] for _ in range(len(deepstack_slice))]
+                        for layer_idx, layer_tokens in enumerate(deepstack_slice):
+                            if layer_tokens is None:
+                                continue
+                            deepstack_collect[layer_idx].append(
+                                layer_tokens.to(
+                                    device=inputs_embeds.device,
+                                    dtype=inputs_embeds.dtype,
+                                )
+                            )
+
+            if deepstack_collect is not None:
+                hidden_dim = inputs_embeds.size(-1)
+                deepstack_layers = [
+                    torch.cat(layer_slices, dim=0)
+                    if layer_slices
+                    else torch.empty(0, hidden_dim, device=inputs_embeds.device, dtype=inputs_embeds.dtype)
+                    for layer_slices in deepstack_collect
+                ]
+        elif pixel_values is not None:
+            # Fallback path: process raw images when slices are not provided (legacy compatibility)
+            if input_ids is None:
+                raise ValueError("input_ids are required to locate visual placeholders")
+            if sequence_lengths is None:
+                raise ValueError("sequence_lengths are required to align visual features")
+            if sum(sequence_lengths) != total_tokens:
+                raise ValueError("sum of sequence_lengths does not match total input tokens")
+
+            image_chunks, deepstack_layers_raw = self.visual(pixel_values, image_grid_thw)
+            if not image_chunks:
+                raise ValueError("The vision encoder did not return valid image features")
+
+            offsets = [0]
+            for length in sequence_lengths:
+                offsets.append(offsets[-1] + length)
+
+            total_replaced = 0
+            deepstack_collect = None
+
+            image_iter = iter(image_chunks)
+            deepstack_iter = [iter(layer) for layer in deepstack_layers_raw] if deepstack_layers_raw else None
+
+            for start, end in zip(offsets[:-1], offsets[1:]):
+                seq_length = end - start
+                if seq_length <= 0:
+                    continue
+
+                try:
+                    token_slice = next(image_iter)
+                except StopIteration:
+                    break
+
+                token_slice = token_slice.to(inputs_embeds.device, inputs_embeds.dtype)
+                slice_len = token_slice.size(0)
+                if slice_len > seq_length:
+                    raise ValueError("Visual tokens exceed the available sequence length")
+
+                inputs_embeds[start : start + slice_len] = token_slice
+                visual_pos_mask[start : start + slice_len] = True
+                total_replaced += slice_len
+
+                if deepstack_iter:
+                    if deepstack_collect is None:
+                        deepstack_collect = [[] for _ in deepstack_layers_raw]
+                    for layer_idx, iterator in enumerate(deepstack_iter):
+                        try:
+                            layer_slice = next(iterator).to(inputs_embeds.device, inputs_embeds.dtype)
+                        except StopIteration:
+                            continue
+                        deepstack_collect[layer_idx].append(layer_slice)
+
+            if deepstack_collect is not None:
+                hidden_dim = inputs_embeds.size(-1)
+                deepstack_layers = [
+                    torch.cat(layer_slices, dim=0)
+                    if layer_slices
+                    else torch.empty(0, hidden_dim, device=inputs_embeds.device, dtype=inputs_embeds.dtype)
+                    for layer_slices in deepstack_collect
+                ]
+            vision_token_count = total_replaced
+
+        if vision_token_count == 0:
+            visual_pos_mask = None
+            deepstack_layers = None
+
+        if positions is None:
+            positions = torch.arange(
+                inputs_embeds.size(0), device=inputs_embeds.device
+            )
+
+        if visual_pos_mask is not None and vision_token_count:
+            visual_pos_mask = visual_pos_mask.to(inputs_embeds.device)
+        else:
+            visual_pos_mask = None
+            deepstack_layers = None
+
+        hidden_states = self.language_model(
+            input_ids=None,
+            positions=positions,
+            inputs_embeds=inputs_embeds,
+            vision_token_count=vision_token_count,
+            visual_pos_mask=visual_pos_mask,
+            deepstack_visual_embeds=deepstack_layers,
+        )
+
+        return hidden_states
+    
+    def compute_logits(self, hidden_states):
+        """Compute logits (delegate to language model)"""
+        return self.language_model.compute_logits(hidden_states)
+
+
+def load_qwen3_vl_model(model_path, config):
+    """
+    Load Qwen3-VL model
+    
+    Args:
+        model_path: Model path
+        config: Configuration object
+    
+    Returns:
+        model: Qwen3VLForConditionalGeneration instance
+    """
+    hf_config = config.hf_config
+    
+    # Create model
+    model = Qwen3VLForConditionalGeneration(hf_config)
+    
+    from nanovllm.utils.loader import load_model
+
+    print("[load_qwen3_vl_model] Loading Qwen3-VL weights...")
+
+    def name_mapping(weight_name: str) -> str | None:
+        if weight_name.startswith("model.language_model."):
+            sub_name = weight_name[len("model.language_model.") :]
+            text_model_prefixes = (
+                "model.",
+                "embed_tokens.",
+                "layers.",
+                "norm.",
+                "rotary_emb.",
+            )
+            if sub_name.startswith(text_model_prefixes):
+                if sub_name.startswith("model."):
+                    sub_name = sub_name[len("model.") :]
+                sub_name = "language_model.model." + sub_name
+            elif sub_name.startswith("lm_head."):
+                sub_name = "language_model.lm_head." + sub_name[len("lm_head.") :]
+            else:
+                sub_name = "language_model." + sub_name
+            return sub_name
+        if weight_name.startswith("model.visual."):
+            sub_name = weight_name[len("model.visual.") :]
+            return "visual.vision." + sub_name
+            return None
+
+    load_model(model, model_path, name_mapping=name_mapping)
+    return model

--- a/nanovllm/utils/loader.py
+++ b/nanovllm/utils/loader.py
@@ -9,20 +9,50 @@ def default_weight_loader(param: nn.Parameter, loaded_weight: torch.Tensor):
     param.data.copy_(loaded_weight)
 
 
-def load_model(model: nn.Module, path: str):
+def load_model(model: nn.Module, path: str, name_mapping=None):
+    """Load safetensors weights into the model.
+
+    Args:
+        model: Target torch module whose parameters will be filled.
+        path: Directory containing *.safetensors files.
+        name_mapping: Optional callable that maps a weight name to the
+            corresponding parameter name. Returning ``None`` skips the weight.
+    """
     packed_modules_mapping = getattr(model, "packed_modules_mapping", {})
     for file in glob(os.path.join(path, "*.safetensors")):
         with safe_open(file, "pt", "cpu") as f:
             for weight_name in f.keys():
-                for k in packed_modules_mapping:
+                target_name = weight_name
+                if name_mapping is not None:
+                    target_name = name_mapping(target_name)
+                    if target_name is None:
+                        continue
+
+                for k, (v, shard_id) in packed_modules_mapping.items():
                     if k in weight_name:
-                        v, shard_id = packed_modules_mapping[k]
-                        param_name = weight_name.replace(k, v)
+                        param_name = target_name
+                        if k in param_name:
+                            param_name = param_name.replace(k, v)
+                        elif k == "gate_proj" and "gate_up_proj" in param_name:
+                            param_name = param_name.replace("gate_up_proj", v)
+                        elif k == "up_proj" and "gate_up_proj" in param_name:
+                            param_name = param_name.replace("gate_up_proj", v)
                         param = model.get_parameter(param_name)
                         weight_loader = getattr(param, "weight_loader")
-                        weight_loader(param, f.get_tensor(weight_name), shard_id)
+                        tensor = f.get_tensor(weight_name)
+                        # Align dtype with the target parameter to avoid
+                        # mismatches when loading mixed precision weights.
+                        if tensor.dtype != param.dtype:
+                            tensor = tensor.to(param.dtype)
+                        weight_loader(param, tensor, shard_id)
                         break
                 else:
-                    param = model.get_parameter(weight_name)
+                    try:
+                        param = model.get_parameter(target_name)
+                    except AttributeError as e:
+                        raise AttributeError(f"Failed to locate parameter '{target_name}' mapped from '{weight_name}'") from e
                     weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                    weight_loader(param, f.get_tensor(weight_name))
+                    tensor = f.get_tensor(weight_name)
+                    if tensor.dtype != param.dtype:
+                        tensor = tensor.to(param.dtype)
+                    weight_loader(param, tensor)


### PR DESCRIPTION
## Summary
- add the Qwen3-VL multimodal model and loader entry so nano-vllm can run vision-language workloads  
- extend engine components (placeholder expansion, vision-cache slicing, KV guard) to mirror vLLM’s multimodal behavior  
- provide `bench_multimodal.py` and `example_multimodal.py` for benchmarking and quick testing  
- document how to download Qwen3-VL-2B-Instruct and where to find the multimodal example

## Benchmark
- GPU: NVIDIA H20 (96GB)  
- Command: `CUDA_VISIBLE_DEVICES=0 python3 bench_multimodal.py --model ~/huggingface/Qwen3-VL-2B-Instruct`  
- Result: 10 requests · 2958 prompt tokens · 2629 generated tokens · 12.49 s latency · 210.55 tok/s throughput

## Testing
- `python3 example_multimodal.py`

## Notes
- large diff because the feature touches model loading, scheduler, and caching; happy to walk through the details if needed  
- if maintainers feel multimodal support shouldn’t land in core yet, I’m open to discussing an extension repo instead