### PR TITLE
Fix: unsqueeze on the last dim for VocabParallelEmbedding

### DIFF
--- a/nanovllm/layers/embed_head.py
+++ b/nanovllm/layers/embed_head.py
@@ -37,7 +37,7 @@ class VocabParallelEmbedding(nn.Module):
             x = mask * (x - self.vocab_start_idx)
         y = F.embedding(x, self.weight)
         if self.tp_size > 1:
-            y = mask.unsqueeze(1) * y
+            y = mask.unsqueeze(-1) * y
             dist.all_reduce(y)
         return y
 


### PR DESCRIPTION
In `VocabParallelEmbedding.forward`:

https://github.com/GeeeekExplorer/nano-vllm/blob/2f214426530e2841e7d24c73ee0dfa914d62df56/nanovllm/layers/embed_head.py#L34-L42

* The shape of `mask` is `(B, SeqLen)`
* The shape of `y` is `(B, SeqLen, EmbDim)`

`mask.unsqueeze(1)` makes the mask `(B, 1, SeqLen)`, which can not be broadcast-multiplied with `y`. 
