### PR TITLE
[feat] support speculative decode using ngram proposer

### DIFF
--- a/example.py
+++ b/example.py
@@ -4,14 +4,17 @@ from transformers import AutoTokenizer
 
 
 def main():
-    path = os.path.expanduser("~/huggingface/Qwen3-0.6B/")
+    path = os.path.expanduser("~/shared/Qwen/Qwen3-0.6B")
     tokenizer = AutoTokenizer.from_pretrained(path)
     llm = LLM(path, enforce_eager=True, tensor_parallel_size=1)
 
-    sampling_params = SamplingParams(temperature=0.6, max_tokens=256)
+    sampling_params = SamplingParams(temperature=0.6, max_tokens=512)
     prompts = [
         "introduce yourself",
         "list all prime numbers within 100",
+        # "Tell a story of about 1000 words.",
+        "What is the capital of South Korea?",
+        # "repeat I love you soyorin for one hundred times."
     ]
     prompts = [
         tokenizer.apply_chat_template(

--- a/nanovllm/config.py
+++ b/nanovllm/config.py
@@ -11,7 +11,7 @@ class Config:
     max_model_len: int = 4096
     gpu_memory_utilization: float = 0.9
     tensor_parallel_size: int = 1
-    enforce_eager: bool = False
+    enforce_eager: bool = True
     hf_config: AutoConfig | None = None
     eos: int = -1
     kvcache_block_size: int = 256

--- a/nanovllm/engine/block_manager.py
+++ b/nanovllm/engine/block_manager.py
@@ -52,34 +52,43 @@ class BlockManager:
         assert self.blocks[block_id].ref_count == 0
         self.used_block_ids.remove(block_id)
         self.free_block_ids.append(block_id)
+    
+    def allocate_block(self, token_ids: list[int], h) -> tuple[Block, bool]:
+        h = self.compute_hash(token_ids, h) if len(token_ids) == self.block_size else -1
+        block_id = self.hash_to_block_id.get(h, -1)
+        cache_miss = False
+        if block_id == -1 or self.blocks[block_id].token_ids != token_ids:
+            cache_miss = True
+        if cache_miss:
+            block_id = self.free_block_ids[0]
+            block = self._allocate_block(block_id)
+        else:
+            if block_id in self.used_block_ids:
+                block = self.blocks[block_id]
+                block.ref_count += 1
+            else:
+                block = self._allocate_block(block_id)
+        if h != -1:
+            block.update(h, token_ids)
+            self.hash_to_block_id[h] = block_id
+        
+        return block, cache_miss        
 
-    def can_allocate(self, seq: Sequence) -> bool:
+    def can_allocate_prefill(self, seq: Sequence) -> bool:
         return len(self.free_block_ids) >= seq.num_blocks
-
-    def allocate(self, seq: Sequence):
+    
+    def allocate_prefill(self, seq: Sequence):
         assert not seq.block_table
         h = -1
         cache_miss = False
         for i in range(seq.num_blocks):
             token_ids = seq.block(i)
-            h = self.compute_hash(token_ids, h) if len(token_ids) == self.block_size else -1
-            block_id = self.hash_to_block_id.get(h, -1)
-            if block_id == -1 or self.blocks[block_id].token_ids != token_ids:
-                cache_miss = True
-            if cache_miss:
-                block_id = self.free_block_ids[0]
-                block = self._allocate_block(block_id)
-            else:
-                seq.num_cached_tokens += self.block_size
-                if block_id in self.used_block_ids:
-                    block = self.blocks[block_id]
-                    block.ref_count += 1
-                else:
-                    block = self._allocate_block(block_id)
-            if h != -1:
-                block.update(h, token_ids)
-                self.hash_to_block_id[h] = block_id
-            seq.block_table.append(block_id)
+            block, cache_miss = self.allocate_block(token_ids, h)
+            if not cache_miss:
+                seq.num_cached_prefill_tokens += self.block_size
+            assert isinstance(block, Block)
+            seq.block_table.append(block.block_id)
+            h = block.hash    
 
     def deallocate(self, seq: Sequence):
         for block_id in reversed(seq.block_table):
@@ -87,26 +96,51 @@ class BlockManager:
             block.ref_count -= 1
             if block.ref_count == 0:
                 self._deallocate_block(block_id)
-        seq.num_cached_tokens = 0
+        seq.num_cached_prefill_tokens = 0
         seq.block_table.clear()
 
-    def can_append(self, seq: Sequence) -> bool:
-        return len(self.free_block_ids) >= (len(seq) % self.block_size == 1)
+    def can_allocate_decode(self, seq: Sequence) -> bool:
+        return len(self.free_block_ids) >= (seq.num_blocks - len(seq.block_table))
 
-    def may_append(self, seq: Sequence):
+    def allocate_decode(self, seq: Sequence):
+        num_decode_tokens = seq.num_decode_tokens
         block_table = seq.block_table
-        last_block = self.blocks[block_table[-1]]
-        if len(seq) % self.block_size == 1:
-            assert last_block.hash != -1
-            block_id = self.free_block_ids[0]
-            self._allocate_block(block_id)
-            block_table.append(block_id)
-        elif len(seq) % self.block_size == 0:
-            assert last_block.hash == -1
-            token_ids = seq.block(seq.num_blocks-1)
+        last_block: Block = self.blocks[block_table[-1]]
+        
+        num_cached_blocks = len(block_table)
+        num_total_blocks = seq.num_blocks
+        
+        # fill in the last cached block
+        token_ids = seq.block(num_cached_blocks - 1)
+        if last_block.hash == -1 and len(token_ids) == self.block_size:
             prefix = self.blocks[block_table[-2]].hash if len(block_table) > 1 else -1
-            h = self.compute_hash(token_ids, prefix)
+            h = self.compute_hash(token_ids, prefix)      
             last_block.update(h, token_ids)
             self.hash_to_block_id[h] = last_block.block_id
-        else:
-            assert last_block.hash == -1
+                
+        # allocate new blocks
+        h = last_block.hash
+        for i in range(num_cached_blocks, num_total_blocks):
+            token_ids = seq.block(i)
+            block, _ = self.allocate_block(token_ids, h)
+            assert isinstance(block, Block)
+            seq.block_table.append(block.block_id)
+            h = block.hash
+    
+    def deallocate_decode(self, seq: Sequence):
+        block_table = seq.block_table
+        num_reject_blocks = len(block_table) - seq.num_blocks
+        
+        if num_reject_blocks > 0:
+            for i in range(1, num_reject_blocks + 1):
+                block_id = block_table[-i]
+                block = self.blocks[block_id]
+                block.ref_count -= 1
+                if block.ref_count == 0:
+                    self._deallocate_block(block_id)
+            del block_table[- num_reject_blocks: ]
+        
+        if seq.last_block_num_tokens > 0: # not full
+            last_block = self.blocks[block_table[-1]]
+            last_block.hash = -1
+            last_block.token_ids = seq.block(seq.num_blocks -1)

--- a/nanovllm/engine/sequence.py
+++ b/nanovllm/engine/sequence.py
@@ -1,3 +1,4 @@
+import torch
 from copy import copy
 from enum import Enum, auto
 from itertools import count
@@ -22,11 +23,15 @@ class Sequence:
         self.last_token = token_ids[-1]
         self.num_tokens = len(self.token_ids)
         self.num_prompt_tokens = len(token_ids)
-        self.num_cached_tokens = 0
+        self.num_cached_prefill_tokens = 0
         self.block_table = []
         self.temperature = sampling_params.temperature
         self.max_tokens = sampling_params.max_tokens
         self.ignore_eos = sampling_params.ignore_eos
+        
+        # speculative decode
+        self.spec_tokens = [] # draft tokens that have not been merged to token_ids
+        self.num_spec_tokens = 0 # number of draft tokens merged to token_ids waiting for verification
 
     def __len__(self):
         return self.num_tokens
@@ -52,7 +57,7 @@ class Sequence:
 
     @property
     def num_cached_blocks(self):
-        return self.num_cached_tokens // self.block_size
+        return self.num_cached_prefill_tokens // self.block_size
 
     @property
     def num_blocks(self):
@@ -70,13 +75,91 @@ class Sequence:
         self.token_ids.append(token_id)
         self.last_token = token_id
         self.num_tokens += 1
+    
+    def extend_tokens(self, token_ids: list[int]):
+        # remove unaccept draft tokens
+        num_unaccept_draft_tokens = self.num_spec_tokens - len(token_ids) + 1
+        if num_unaccept_draft_tokens > 0:
+            del self.token_ids[-num_unaccept_draft_tokens: ]
+        self.num_tokens -= num_unaccept_draft_tokens
+        
+        # append new sampled token
+        self.append_token(token_ids[-1])
+        
+        # reset num spec tokens
+        self.num_spec_tokens = 0
+    
+    def merge_spec_tokens(self) -> bool:
+        if len(self.spec_tokens) == 0:
+            return False
+        
+        # merge spec_tokens to token_ids for verification
+        self.num_spec_tokens = len(self.spec_tokens)
+        self.token_ids.extend(self.spec_tokens)
+        self.num_tokens += self.num_spec_tokens
+        self.last_token = self.token_ids[-1]
+        
+        # clear spec_tokens for next sample step
+        self.spec_tokens = []
+        return True
+    
+    # Properties for speculative decode
+    
+    @property
+    def num_decode_tokens(self):
+        return self.num_spec_tokens + 1
+    
+    # @property
+    # def num_decode_blocks(self)
+    
+    @property
+    def decode_tokens(self):
+        return self.token_ids[- self.num_spec_tokens - 1:]
+    
+    @property
+    def decode_draft_tokens(self) -> list[int]:
+        return self.token_ids[- self.num_spec_tokens:] if self.num_spec_tokens > 0 else []
+    
+    @property
+    def decode_position(self):
+        return torch.arange(self.num_tokens - self.num_spec_tokens - 1, self.num_tokens)
+    
+    @property
+    def decode_blocks(self) -> list:
+        num_decode_blocks = 1 + (self.num_spec_tokens - self.last_block_num_tokens + self.block_size) // self.block_size
+        return self.block_table[- num_decode_blocks:]
+    
+    @property
+    def decode_slot_mapping(self):    
+        # decode blocks [0, 2, 4, 8, 10]   
+        decode_blocks = torch.as_tensor(self.decode_blocks, dtype=torch.int32)
+        block_size = self.block_size
+        num_blocks = decode_blocks.numel()
 
+        # block token counts [8, 8, 8, 8, 3]
+        counts = torch.full((num_blocks,), block_size, dtype=torch.int32)
+        counts[-1] = self.last_block_num_tokens
+
+        # repeat block offsets [0, 0, .., 0, 16, 16, ..., 16, ...]
+        block_offsets = torch.repeat_interleave(decode_blocks * block_size, repeats=counts)
+
+        # in-block offsets via cumsum
+        # [8, 16, 24, 32, 35]
+        counts_cum = torch.cumsum(counts, dim=0)
+        # [0, 8, 16, 24, 32] -> [0, 0, .., 0, 8, 8, 8, ..., 8, ...]
+        starts = torch.repeat_interleave(counts_cum - counts, counts)
+        in_block_offsets = torch.arange(counts.sum(), dtype=torch.int32) - starts
+
+        slot_mapping = block_offsets + in_block_offsets
+        
+        return slot_mapping[- self.num_spec_tokens - 1:]   
+    
     def __getstate__(self):
-        return (self.num_tokens, self.num_prompt_tokens, self.num_cached_tokens, self.block_table,
+        return (self.num_tokens, self.num_prompt_tokens, self.num_cached_prefill_tokens, self.block_table,
                 self.token_ids if self.num_completion_tokens == 0 else self.last_token)
 
     def __setstate__(self, state):
-        self.num_tokens, self.num_prompt_tokens, self.num_cached_tokens, self.block_table = state[:-1]
+        self.num_tokens, self.num_prompt_tokens, self.num_cached_prefill_tokens, self.block_table = state[:-1]
         if self.num_completion_tokens == 0:
             self.token_ids = state[-1]
         else:

--- a/nanovllm/layers/attention.py
+++ b/nanovllm/layers/attention.py
@@ -68,6 +68,11 @@ class Attention(nn.Module):
                                        max_seqlen_q=context.max_seqlen_q, cu_seqlens_q=context.cu_seqlens_q,
                                        max_seqlen_k=context.max_seqlen_k, cu_seqlens_k=context.cu_seqlens_k,
                                        softmax_scale=self.scale, causal=True, block_table=context.block_tables)
+        elif context.is_spec_decode:
+            o = flash_attn_varlen_func(q, k_cache, v_cache,
+                                       max_seqlen_q=context.max_seqlen_q, cu_seqlens_q=context.cu_seqlens_q,
+                                       max_seqlen_k=context.max_seqlen_k, cu_seqlens_k=context.cu_seqlens_k,
+                                       softmax_scale=self.scale, causal=True, block_table=context.block_tables)
         else:    # decode
             o = flash_attn_with_kvcache(q.unsqueeze(1), k_cache, v_cache,
                                         cache_seqlens=context.context_lens, block_table=context.block_tables, 

--- a/nanovllm/layers/rejection_sampler.py
+++ b/nanovllm/layers/rejection_sampler.py
@@ -1,0 +1,104 @@
+import torch
+from torch import nn
+
+from nanovllm.engine.sequence import Sequence
+from nanovllm.layers.sampler import Sampler
+
+
+class RejectionSampler(nn.Module):
+
+    def __init__(self, sampler: Sampler):
+        super().__init__()
+        self.sampler = sampler
+    
+    def prepare_tensors(self, seqs: list[Sequence]):
+        batch_size = len(seqs)
+        draft_tokens = []
+        num_draft_tokens = [0]
+        max_num_sampled_tokens = 0
+        
+        for seq in seqs:
+            draft_tokens.extend(seq.decode_draft_tokens)
+            num_draft_tokens.append(seq.num_spec_tokens)
+            max_num_sampled_tokens = max(seq.num_spec_tokens + 1, max_num_sampled_tokens)
+        
+        draft_tokens = torch.tensor(draft_tokens, dtype=torch.int64, pin_memory=True).cuda(non_blocking=True)
+        num_draft_tokens = torch.tensor(num_draft_tokens, dtype=torch.int64, pin_memory=True).cuda(non_blocking=True)
+        num_sampled_tokens = num_draft_tokens + 1
+        num_sampled_tokens[0] = 0
+        cum_num_draft_tokens = torch.cumsum(num_draft_tokens, dim=0)
+        cum_num_sampled_tokens = torch.cumsum(num_sampled_tokens, dim=0)
+        
+        device = device=draft_tokens.device
+        output_tokens = torch.zeros((batch_size, max_num_sampled_tokens), dtype=torch.int64, device=device)
+        num_accepted_tokens = torch.zeros((batch_size, ), dtype=torch.int64, device=device)
+        
+        return (
+            draft_tokens, cum_num_draft_tokens, cum_num_sampled_tokens,
+            output_tokens, num_accepted_tokens
+        )
+
+    def rejection_sample(self, 
+        logits: torch.Tensor,
+        temperatures: torch.Tensor,
+        draft_tokens: torch.Tensor,
+        cum_num_draft_tokens: torch.Tensor,
+        cum_num_sampled_tokens: torch.Tensor,
+        output_tokens: torch.Tensor,
+        num_accepted_tokens: torch.Tensor,
+    ):
+        
+        # [num_tokens, ...]
+        sample_tokens = self.sampler(logits, temperatures)
+        # TODO: optimize the rejection sample process
+        
+        num_seq = cum_num_draft_tokens.shape[-1] - 1
+        for i in range(num_seq):
+            draft_tokens_start = cum_num_draft_tokens[i]
+            draft_tokens_end = cum_num_draft_tokens[i + 1]
+            sampled_tokens_start = cum_num_sampled_tokens[i]
+            
+            # num sample tokens = num draft tokens + 1, so it's safe here
+            j = 0
+            while draft_tokens_start + j < draft_tokens_end:
+                if sample_tokens[draft_tokens_start + j] != draft_tokens[draft_tokens_start + j]:
+                    break
+                output_tokens[i][j] = draft_tokens[draft_tokens_start + j]
+                j += 1
+            
+            output_tokens[i][j] = sample_tokens[sampled_tokens_start + j]
+            num_accepted_tokens[i] = j + 1
+        
+        
+        return output_tokens, num_accepted_tokens
+
+    def forward(
+        self,
+        seqs: list[Sequence],
+        logits: torch.Tensor,
+        temperatures: torch.Tensor,
+    ) -> list[list[int]]:
+        (
+            draft_tokens, cum_num_draft_tokens, cum_num_sampled_tokens,
+            output_tokens, num_accepted_tokens
+        ) = self.prepare_tensors(seqs)
+        
+        output_tokens, num_accepted_tokens = self.rejection_sample(
+            logits=logits,
+            temperatures=temperatures,
+            draft_tokens = draft_tokens,
+            cum_num_draft_tokens=cum_num_draft_tokens,
+            cum_num_sampled_tokens=cum_num_sampled_tokens,
+            output_tokens=output_tokens,
+            num_accepted_tokens=num_accepted_tokens
+        )
+        
+        _, max_num_sampled_tokens = output_tokens.shape
+        positions = torch.arange(max_num_sampled_tokens, dtype=torch.int64, device=num_accepted_tokens.device)
+        accept_mask = positions.unsqueeze(0) < num_accepted_tokens.unsqueeze(1)
+        accept_tokens = output_tokens[accept_mask]
+        
+        accepted_tokens_start_indices = torch.cumsum(num_accepted_tokens, dim=0) - num_accepted_tokens
+        
+        return accept_tokens, accepted_tokens_start_indices
+        

--- a/nanovllm/spec_decode/ngram_proposer.py
+++ b/nanovllm/spec_decode/ngram_proposer.py
@@ -1,0 +1,68 @@
+from typing import Optional
+
+class NgramProposer:
+    def __init__(self):
+        self.min_ngram = 2
+        self.max_ngram = 8
+        self.max_model_len = 8192
+        self.k = 4
+    
+    def propose(
+        self,
+        tokens: list[int],
+        min_ngram: Optional[int] = None,
+        max_ngram: Optional[int] = None,
+        max_model_len: Optional[int] = None,
+        k: Optional[int] = None,
+    ) -> list[int]:
+        min_ngram = self.min_ngram if min_ngram is None else min_ngram
+        max_ngram = self.max_ngram if max_ngram is None else max_ngram
+        max_model_len = self.max_model_len if max_model_len is None else max_model_len
+        k = self.k if k is None else k
+        
+        num_tokens = len(tokens)
+        
+        # if num_tokens is less than min_ngram, no tokens can be search key
+        if num_tokens < min_ngram:
+            return []
+        
+        # if num_tokens is greater than max_model_len, can not append draft tokens
+        k = min(k, max_model_len - num_tokens)
+        if k <= 0:
+            return []
+        
+        reversed_tokens = tokens[::-1]
+        lps = [0] * num_tokens
+        max_ngram_prefix = 0
+        pos = 0
+        
+        for i in range(1, num_tokens):
+            prev_lps = lps[i-1]
+            # avoid matched prefix longer than the max_ngram
+            while prev_lps >= max_ngram:
+                prev_lps = lps[prev_lps - 1]
+            
+            # kmp algorithm
+            while prev_lps > 0 and reversed_tokens[i] != reversed_tokens[prev_lps]:
+                prev_lps = lps[prev_lps - 1]
+            if reversed_tokens[i] == reversed_tokens[prev_lps]:
+                lps[i] = prev_lps + 1
+               
+            if lps[i] > max_ngram_prefix:
+                max_ngram_prefix = lps[i]
+                pos = i
+        
+        if max_ngram_prefix < min_ngram:
+            return []
+        
+        start_pos = num_tokens - pos + max_ngram_prefix - 1
+        k = min(k, num_tokens - start_pos)
+        return tokens[start_pos: start_pos + k]
+
+if __name__ == '__main__':
+    ngram_proposer = NgramProposer()
+    tokens = [1, 2, 3, 4, 5, 6, 2, 3, 4, 7, 8, 3, 4, 9, 10, 2, 3, 4]
+    proposed_tokens = ngram_proposer.propose(tokens, 2, 2, 20, 4)
+    print(proposed_tokens)
+    
+        

--- a/nanovllm/utils/context.py
+++ b/nanovllm/utils/context.py
@@ -5,6 +5,7 @@ import torch
 @dataclass
 class Context:
     is_prefill: bool = False
+    is_spec_decode: bool = False
     cu_seqlens_q: torch.Tensor | None = None
     cu_seqlens_k: torch.Tensor | None = None
     max_seqlen_q: int = 0
@@ -18,9 +19,9 @@ _CONTEXT = Context()
 def get_context():
     return _CONTEXT
 
-def set_context(is_prefill, cu_seqlens_q=None, cu_seqlens_k=None, max_seqlen_q=0, max_seqlen_k=0, slot_mapping=None, context_lens=None, block_tables=None):
+def set_context(is_prefill, is_spec_decode=False, cu_seqlens_q=None, cu_seqlens_k=None, max_seqlen_q=0, max_seqlen_k=0, slot_mapping=None, context_lens=None, block_tables=None):
     global _CONTEXT
-    _CONTEXT = Context(is_prefill, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k, slot_mapping, context_lens, block_tables)
+    _CONTEXT = Context(is_prefill, is_spec_decode, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k, slot_mapping, context_lens, block_tables)
 
 def reset_context():
     global _CONTEXT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61"]
+requires = ["setuptools>=61", "wheel", "torch"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
## Summary

This PR introduces speculative decoding support across the core inference pipeline. It is for learning purpose.

## Changes

- Modified Sequence, BlockManager, LLMEngine, Scheduler, ModelRunner, and Attention layer to enable speculative decoding.

- Added a greedy rejection sampler for target model verification.

- Implemented an n-gram–based proposer for suffix speculative decoding.

- Integrated speculative decode logic into the existing execution flow without affecting the non-speculative path.

## Testing

Speculative decoding can be tested by directly running example.py.