### PR TITLE
Modify may_append logic for block appending

### DIFF
--- a/nanovllm/engine/block_manager.py
+++ b/nanovllm/engine/block_manager.py
@@ -96,17 +96,17 @@ class BlockManager:
     def may_append(self, seq: Sequence):
         block_table = seq.block_table
         last_block = self.blocks[block_table[-1]]
-        if len(seq) % self.block_size == 1:
+        if len(seq) % self.block_size == 0:
             assert last_block.hash != -1
             block_id = self.free_block_ids[0]
             self._allocate_block(block_id)
             block_table.append(block_id)
-        elif len(seq) % self.block_size == 0:
-            assert last_block.hash == -1
-            token_ids = seq.block(seq.num_blocks-1)
-            prefix = self.blocks[block_table[-2]].hash if len(block_table) > 1 else -1
-            h = self.compute_hash(token_ids, prefix)
-            last_block.update(h, token_ids)
-            self.hash_to_block_id[h] = last_block.block_id
+        #elif (len(seq)+1) % self.block_size == 0:
+        #    assert last_block.hash == -1
+        #    token_ids = seq.block(seq.num_blocks-1)
+        #    prefix = self.blocks[block_table[-2]].hash if len(block_table) > 1 else -1
+        #    h = self.compute_hash(token_ids, prefix)
+        #    last_block.update(h, token_ids)
+        #    self.hash_to_block_id[h] = last_block.block_id
         else:
             assert last_block.hash == -1


### PR DESCRIPTION
Updated the may_append method to change the condition for appending a block and commented out the previous logic for handling the case when the sequence length is a multiple of the block size.