### PR TITLE
fix: clean up hash_to_block_id mapping when deallocating blocks

### DIFF
--- a/nanovllm/engine/block_manager.py
+++ b/nanovllm/engine/block_manager.py
@@ -50,6 +50,8 @@ class BlockManager:
 
     def _deallocate_block(self, block_id: int) -> Block:
         assert self.blocks[block_id].ref_count == 0
+        if self.blocks[block_id].hash != -1:
+            self.hash_to_block_id.pop(self.blocks[block_id].hash, None)        
         self.used_block_ids.remove(block_id)
         self.free_block_ids.append(block_id)
 

--- a/nanovllm/engine/block_manager.py
+++ b/nanovllm/engine/block_manager.py
@@ -48,7 +48,7 @@ class BlockManager:
         self.used_block_ids.add(block_id)
         return self.blocks[block_id]
 
-    def _deallocate_block(self, block_id: int) -> Block:
+    def _deallocate_block(self, block_id: int):
         assert self.blocks[block_id].ref_count == 0
         if self.blocks[block_id].hash != -1:
             self.hash_to_block_id.pop(self.blocks[block_id].hash, None)        


### PR DESCRIPTION
Problem
In the BlockManager._deallocate_block method, when deallocating a block, the corresponding entry in the hash_to_block_id dictionary was not being removed. This causes the hash mapping of deallocated blocks to remain in the dictionary, leading to potential issues:
Memory leak: invalid mappings accumulate in the dictionary over time
Logic error: may incorrectly reference deallocated blocks

Solution
Add hash mapping cleanup logic in the _deallocate_block method:
Check if the block being deallocated has a valid hash value (hash != -1)
If so, remove the corresponding mapping from the hash_to_block_id dictionary

Changes
File: nanovllm/engine/block_manager.py
Method: _deallocate_block
Added: hash mapping cleanup logic using pop() with safe default