### PR TITLE
fix(rms_norm): add copy for residual

### DIFF
--- a/nanovllm/layers/layernorm.py
+++ b/nanovllm/layers/layernorm.py
@@ -33,7 +33,7 @@ class RMSNorm(nn.Module):
     ) -> tuple[torch.Tensor, torch.Tensor]:
         orig_dtype = x.dtype
         x = x.float().add_(residual.float())
-        residual = x.to(orig_dtype)
+        residual = x.to(orig_dtype).clone()
         var = x.pow(2).mean(dim=-1, keepdim=True)
         x.mul_(torch.rsqrt(var + self.eps))
         x = x.to(orig_dtype).mul_(self.weight)


### PR DESCRIPTION
## 情况说明
`residual` 引用了 `x`，导致实际返回的是俩 x