### PR TITLE
enable 'slots=True' for dataclasses

### DIFF
--- a/nanovllm/config.py
+++ b/nanovllm/config.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from transformers import AutoConfig
 
 
-@dataclass
+@dataclass(slots=True)
 class Config:
     model: str
     max_num_batched_tokens: int = 16384

--- a/nanovllm/sampling_params.py
+++ b/nanovllm/sampling_params.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 
-@dataclass
+@dataclass(slots=True)
 class SamplingParams:
     temperature: float = 1.0
     max_tokens: int = 64

--- a/nanovllm/utils/context.py
+++ b/nanovllm/utils/context.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 import torch
 
 
-@dataclass
+@dataclass(slots=True)
 class Context:
     is_prefill: bool = False
     cu_seqlens_q: torch.Tensor | None = None


### PR DESCRIPTION
Enabling `slots=True` for the `Config`, `SamplingParams`, and `Context` dataclasses to reduce memory overhead and improve access speed.