### PR TITLE
fix: rope_scaling unhashable dict error with transformers>=5.1.0

### DIFF
--- a/nanovllm/layers/rotary_embedding.py
+++ b/nanovllm/layers/rotary_embedding.py
@@ -48,7 +48,34 @@ class RotaryEmbedding(nn.Module):
         return query, key
 
 
+def _normalize_rope_scaling(
+    rope_scaling: dict | None,
+) -> None:
+    if rope_scaling is None:
+        return None
+    rope_type = rope_scaling.get("rope_type", rope_scaling.get("type"))
+    if rope_type == "default":
+        return None
+    if rope_type is None and set(rope_scaling).issubset({"rope_theta"}):
+        return None
+    raise NotImplementedError(
+        f"Unsupported rope_scaling={rope_scaling!r}. "
+        "nano-vllm only supports default RoPE without scaling."
+    )
+
+
 @lru_cache(1)
+def _get_rope(
+    head_size: int,
+    rotary_dim: int,
+    max_position: int,
+    base: float,
+    rope_scaling: None = None,
+):
+    rotary_emb = RotaryEmbedding(head_size, rotary_dim, max_position, base)
+    return rotary_emb
+
+
 def get_rope(
     head_size: int,
     rotary_dim: int,
@@ -56,6 +83,5 @@ def get_rope(
     base: float,
     rope_scaling: dict | None = None,
 ):
-    assert rope_scaling is None
-    rotary_emb = RotaryEmbedding(head_size, rotary_dim, max_position, base)
-    return rotary_emb
+    rope_scaling = _normalize_rope_scaling(rope_scaling)
+    return _get_rope(head_size, rotary_dim, max_position, base, rope_scaling)

--- a/nanovllm/models/qwen3.py
+++ b/nanovllm/models/qwen3.py
@@ -56,7 +56,7 @@ class Qwen3Attention(nn.Module):
             rotary_dim=self.head_dim,
             max_position=max_position,
             base=rope_theta,
-            rope_scaling=rope_scaling,
+            rope_scaling=None,
         )
         self.attn = Attention(
             self.num_heads,

--- a/nanovllm/models/qwen3.py
+++ b/nanovllm/models/qwen3.py
@@ -23,7 +23,7 @@ class Qwen3Attention(nn.Module):
         rms_norm_eps: float = 1e-06,
         qkv_bias: bool = False,
         rope_theta: float = 10000,
-        rope_scaling: tuple | None = None,
+        rope_scaling: dict | None = None,
     ) -> None:
         super().__init__()
         tp_size = dist.get_world_size()
@@ -56,7 +56,7 @@ class Qwen3Attention(nn.Module):
             rotary_dim=self.head_dim,
             max_position=max_position,
             base=rope_theta,
-            rope_scaling=None,
+            rope_scaling=rope_scaling,
         )
         self.attn = Attention(
             self.num_heads,


### PR DESCRIPTION
## Summary
- Fix `TypeError: unhashable type: 'dict'` when using Qwen3 with `transformers>=5.1.0`
- Newer transformers versions initialize `rope_scaling` as a dict (e.g. `{'rope_theta': 1000000, 'rope_type': 'default'}`) instead of `None`, which breaks `@lru_cache` in `get_rope`
- Explicitly pass `rope_scaling=None` in `Qwen3Attention` since RoPE scaling is not yet implemented

Fixes #167

## Test plan
- [x] Verified with Qwen3-0.6B model, generation works correctly after the fix