### PR TITLE
fix: update download command for model weights in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install git+https://github.com/GeeeekExplorer/nano-vllm.git
 
 To download the model weights manually, use the following command:
 ```bash
-huggingface-cli download --resume-download Qwen/Qwen3-0.6B \
+hf download --resume-download Qwen/Qwen3-0.6B \
   --local-dir ~/huggingface/Qwen3-0.6B/ \
   --local-dir-use-symlinks False
 ```


### PR DESCRIPTION
Warning: 'huggingface-cli download' is deprecated. Use 'hf download' instead. 