### PR TITLE
Fix CUDA graph block_tables shape mismatch

### DIFF
--- a/nanovllm/config.py
+++ b/nanovllm/config.py
@@ -9,6 +9,7 @@ class Config:
     max_num_batched_tokens: int = 16384
     max_num_seqs: int = 512
     max_model_len: int = 4096
+    max_seq_len_to_capture: int | None = None
     gpu_memory_utilization: float = 0.9
     tensor_parallel_size: int = 1
     enforce_eager: bool = False
@@ -23,4 +24,9 @@ class Config:
         assert 1 <= self.tensor_parallel_size <= 8
         self.hf_config = AutoConfig.from_pretrained(self.model)
         self.max_model_len = min(self.max_model_len, self.hf_config.max_position_embeddings)
+        if self.max_seq_len_to_capture is None:
+            self.max_seq_len_to_capture = self.max_model_len
+        else:
+            assert self.max_seq_len_to_capture > 0
+            self.max_seq_len_to_capture = min(self.max_seq_len_to_capture, self.max_model_len)
         assert self.max_num_batched_tokens >= self.max_model_len

--- a/nanovllm/engine/model_runner.py
+++ b/nanovllm/engine/model_runner.py
@@ -201,6 +201,7 @@ class ModelRunner:
             graph_vars["slot_mapping"][:bs] = context.slot_mapping
             graph_vars["context_lens"].zero_()
             graph_vars["context_lens"][:bs] = context.context_lens
+            graph_vars["block_tables"].fill_(-1)
             graph_vars["block_tables"][:bs, :context.block_tables.size(1)] = context.block_tables
             graph.replay()
             return self.model.compute_logits(graph_vars["outputs"][:bs])
@@ -218,7 +219,9 @@ class ModelRunner:
         config = self.config
         hf_config = config.hf_config
         max_bs = min(self.config.max_num_seqs, 512)
-        max_num_blocks = (config.max_model_len + self.block_size - 1) // self.block_size
+        # Runtime decode replay can require one more block-table column than the
+        # nominal max_model_len/block_size width captured here.
+        max_num_blocks = (config.max_model_len + self.block_size - 1) // self.block_size + 1
         input_ids = torch.zeros(max_bs, dtype=torch.int64)
         positions = torch.zeros(max_bs, dtype=torch.int64)
         slot_mapping = torch.zeros(max_bs, dtype=torch.int32)

--- a/nanovllm/engine/model_runner.py
+++ b/nanovllm/engine/model_runner.py
@@ -186,9 +186,21 @@ class ModelRunner:
         temperatures = torch.tensor(temperatures, dtype=torch.float32, pin_memory=True).cuda(non_blocking=True)
         return temperatures
 
+    def can_use_decode_graph(self, input_ids: torch.Tensor, is_prefill: bool) -> bool:
+        if is_prefill or self.enforce_eager or input_ids.size(0) > 512:
+            return False
+        context = get_context()
+        if context.context_lens is None or context.block_tables is None:
+            return False
+        if int(context.context_lens.max().item()) > self.config.max_seq_len_to_capture:
+            return False
+        if context.block_tables.size(1) > self.graph_vars["block_tables"].size(1):
+            return False
+        return True
+
     @torch.inference_mode()
     def run_model(self, input_ids: torch.Tensor, positions: torch.Tensor, is_prefill: bool):
-        if is_prefill or self.enforce_eager or input_ids.size(0) > 512:
+        if not self.can_use_decode_graph(input_ids, is_prefill):
             return self.model.compute_logits(self.model(input_ids, positions))
         else:
             bs = input_ids.size(0)
@@ -219,9 +231,7 @@ class ModelRunner:
         config = self.config
         hf_config = config.hf_config
         max_bs = min(self.config.max_num_seqs, 512)
-        # Runtime decode replay can require one more block-table column than the
-        # nominal max_model_len/block_size width captured here.
-        max_num_blocks = (config.max_model_len + self.block_size - 1) // self.block_size + 1
+        max_num_blocks = (config.max_seq_len_to_capture + self.block_size - 1) // self.block_size + 1
         input_ids = torch.zeros(max_bs, dtype=torch.int64)
         positions = torch.zeros(max_bs, dtype=torch.int64)
         slot_mapping = torch.zeros(max_bs, dtype=torch.int32)


### PR DESCRIPTION
 Closes #190
 ## What

  Add an explicit decode CUDA graph eligibility check and fall back to eager execution when the runtime decode batch exceeds the captured
  graph coverage.

  ## Why

  Decode CUDA graph replay currently assumes that runtime decode state always fits the graph buffers captured up front from
  `max_model_len`.

  Under higher-concurrency / longer-context workloads, this assumption can break. One concrete failure mode is:

  ```text
  RuntimeError: The expanded size of the tensor (...) must match the existing size (...)

  caused by context.block_tables being wider than the captured graph buffer.

  The broader issue is that replay is attempted even when runtime decode state is outside the graph coverage window.

  ## How

  This patch makes CUDA graph replay conditional on runtime eligibility:

  1. Add max_seq_len_to_capture to config, defaulting to max_model_len.
  2. Size captured decode graph buffers from max_seq_len_to_capture.
  3. Before replay, check that:
      - the step is decode-only
      - eager is not forced
      - batch size is within captured graph support
      - max decode context length is within max_seq_len_to_capture
      - runtime block_tables width fits the captured graph buffer
  4. If any check fails, fall back to eager execution instead of replaying the graph.
  5. Clear the reused block_tables graph buffer with -1 before copying the current step's values.

  ## Validation

  - python -m py_compile nanovllm/config.py nanovllm/engine/model_runner.py passes.
  - The change is local to decode CUDA graph selection / replay.
  - The same design has been validated locally in a derived codebase by running longer-context serving benchmarks that previously
    exercised graph boundary conditions without crashing.

  ## Notes

  This keeps CUDA graph as an optimization path rather than a correctness assumption.

  It is intentionally conservative: runtime decode batches outside the capture window are handled by eager execution.