### PR TITLE
fix: correct postprocess return type annotation

### DIFF
--- a/nanovllm/engine/scheduler.py
+++ b/nanovllm/engine/scheduler.py
@@ -62,7 +62,7 @@ class Scheduler:
         self.block_manager.deallocate(seq)
         self.waiting.appendleft(seq)
 
-    def postprocess(self, seqs: list[Sequence], token_ids: list[int]) -> list[bool]:
+    def postprocess(self, seqs: list[Sequence], token_ids: list[int]) -> None:
         for seq, token_id in zip(seqs, token_ids):
             seq.append_token(token_id)
             if (not seq.ignore_eos and token_id == self.eos) or seq.num_completion_tokens == seq.max_tokens:


### PR DESCRIPTION
## Summary

Fix incorrect return type annotation in `Scheduler.postprocess()`.

## Problem

The `postprocess` method declares return type `-> list[bool]` but has no return statement:

```python
def postprocess(self, seqs: list[Sequence], token_ids: list[int]) -> list[bool]:  # ❌ Wrong
    for seq, token_id in zip(seqs, token_ids):
        seq.append_token(token_id)
        if (not seq.ignore_eos and token_id == self.eos) or seq.num_completion_tokens == seq.max_tokens:
            seq.status = SequenceStatus.FINISHED
            self.block_manager.deallocate(seq)
            self.running.remove(seq)
    # No return statement! Actually returns None
```

This causes type checker warnings (mypy, pyright, etc.)

## Fix

Corrected the type annotation to match the actual implementation:

```python
def postprocess(self, seqs: list[Sequence], token_ids: list[int]) -> None:  # ✅ Correct
```

No functional changes were made to the code logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)