### PR TITLE
[Feat] Add PyTorch Profiler support for performance analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,24 @@ outputs = llm.generate(prompts, sampling_params)
 outputs[0]["text"]
 ```
 
+## Profiling
+
+Enable PyTorch profiler to trace per-process performance when using tensor parallelism:
+
+```python
+llm = LLM(
+    "/YOUR/MODEL/PATH",
+    enable_profiling=True,
+    profiling_output_dir="./profiler_logs",
+)
+
+# Run inference...
+# Then view traces with TensorBoard:
+# tensorboard --logdir=./profiler_logs
+```
+
+The profiler traces are saved per rank (e.g., `rank0`, `rank1`) and can be analyzed using TensorBoard to identify performance bottlenecks in multi-process inference.
+
 ## Benchmark
 
 See `bench.py` for benchmark.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ llm = LLM(
 # tensorboard --logdir=./profiler_logs
 ```
 
-The profiler traces are saved per rank (e.g., `rank0`, `rank1`) and can be analyzed using TensorBoard to identify performance bottlenecks in multi-process inference.
+The profiler traces are saved per rank (e.g., `rank0`, `rank1`) and can be analyzed using https://ui.perfetto.dev/ to identify performance bottlenecks in multi-process inference.
 
 ## Benchmark
 

--- a/nanovllm/engine/llm_engine.py
+++ b/nanovllm/engine/llm_engine.py
@@ -14,7 +14,7 @@ from nanovllm.engine.model_runner import ModelRunner
 
 class LLMEngine:
 
-    def __init__(self, model, **kwargs):
+    def __init__(self, model, enable_profiling: bool = False, profiling_output_dir: str = "./profiler_logs", **kwargs):
         config_fields = {field.name for field in fields(Config)}
         config_kwargs = {k: v for k, v in kwargs.items() if k in config_fields}
         config = Config(model, **config_kwargs)
@@ -23,11 +23,11 @@ class LLMEngine:
         ctx = mp.get_context("spawn")
         for i in range(1, config.tensor_parallel_size):
             event = ctx.Event()
-            process = ctx.Process(target=ModelRunner, args=(config, i, event))
+            process = ctx.Process(target=ModelRunner, args=(config, i, event, enable_profiling, profiling_output_dir))
             process.start()
             self.ps.append(process)
             self.events.append(event)
-        self.model_runner = ModelRunner(config, 0, self.events)
+        self.model_runner = ModelRunner(config, 0, self.events, enable_profiling, profiling_output_dir)
         self.tokenizer = AutoTokenizer.from_pretrained(config.model, use_fast=True)
         config.eos = self.tokenizer.eos_token_id
         self.scheduler = Scheduler(config)

--- a/nanovllm/engine/model_runner.py
+++ b/nanovllm/engine/model_runner.py
@@ -1,4 +1,6 @@
+import os
 import pickle
+from contextlib import nullcontext
 import torch
 import torch.distributed as dist
 from multiprocessing.synchronize import Event
@@ -14,7 +16,7 @@ from nanovllm.utils.loader import load_model
 
 class ModelRunner:
 
-    def __init__(self, config: Config, rank: int, event: Event | list[Event]):
+    def __init__(self, config: Config, rank: int, event: Event | list[Event], enable_profiling: bool = False, profiling_output_dir: str = "./profiler_logs"):
         self.config = config
         hf_config = config.hf_config
         self.block_size = config.kvcache_block_size
@@ -22,6 +24,9 @@ class ModelRunner:
         self.world_size = config.tensor_parallel_size
         self.rank = rank
         self.event = event
+        self.enable_profiling = enable_profiling
+        self.profiling_output_dir = profiling_output_dir
+        self.profiler = None
 
         dist.init_process_group("nccl", "tcp://localhost:2333", world_size=self.world_size, rank=rank)
         torch.cuda.set_device(rank)
@@ -38,6 +43,10 @@ class ModelRunner:
         torch.set_default_device("cpu")
         torch.set_default_dtype(default_dtype)
 
+        # Setup profiler after model is ready
+        if self.enable_profiling:
+            self._setup_profiler()
+
         if self.world_size > 1:
             if rank == 0:
                 self.shm = SharedMemory(name="nanovllm", create=True, size=2**20)
@@ -47,7 +56,44 @@ class ModelRunner:
                 self.shm = SharedMemory(name="nanovllm")
                 self.loop()
 
+    def _setup_profiler(self):
+        """Setup PyTorch profiler for performance tracing."""
+        import torch.profiler
+        import os
+
+        os.makedirs(self.profiling_output_dir, exist_ok=True)
+        worker_name = f"rank{self.rank}"
+
+        profiler_schedule = torch.profiler.schedule(
+            wait=1,
+            warmup=1,
+            active=3,
+            repeat=1,
+        )
+
+        self.profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=profiler_schedule,
+            # 建议开启 record_shapes 和 profile_memory 以获得更详细的分析
+            record_shapes=True, 
+            profile_memory=True,
+            with_stack=True,
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(
+                self.profiling_output_dir,
+                worker_name=worker_name,
+            ),
+        )
+        # 添加标志位，防止重复启动
+        self.profiler_started = False
+        print(f"[Rank {self.rank}] Profiler enabled. Traces will be saved to: {self.profiling_output_dir}")
+
     def exit(self):
+        # Stop profiler before exit
+        if self.profiler is not None:
+            self.profiler.stop()
         if self.world_size > 1:
             self.shm.close()
             dist.barrier()
@@ -206,12 +252,29 @@ class ModelRunner:
             return self.model.compute_logits(graph_vars["outputs"][:bs])
 
     def run(self, seqs: list[Sequence], is_prefill: bool) -> list[int]:
+        # 1. 懒加载启动：在第一次推理时启动 profiler
+        # 这样可以避免抓取初始化时的开销，只抓取实际推理过程
+        if self.profiler is not None and not self.profiler_started:
+            self.profiler.start()
+            self.profiler_started = True
+
+        # 2. 正常执行推理逻辑（移除 with 语句）
         input_ids, positions = self.prepare_prefill(seqs) if is_prefill else self.prepare_decode(seqs)
         temperatures = self.prepare_sample(seqs) if self.rank == 0 else None
+        
         logits = self.run_model(input_ids, positions, is_prefill)
         token_ids = self.sampler(logits, temperatures).tolist() if self.rank == 0 else None
+        
         reset_context()
+
+        # 3. 推进 Schedule
+        # 根据 wait=1, warmup=1, active=3 的配置，
+        # 前 2 次调用 step() 不会记录，后 3 次会记录，之后自动停止记录
+        if self.profiler is not None:
+            self.profiler.step()
+            
         return token_ids
+
 
     @torch.inference_mode()
     def capture_cudagraph(self):


### PR DESCRIPTION
## Motivation
Currently, `nano-vllm` lacks a built-in mechanism for performance analysis. Users have to manually insert profiler code into the source code to debug inference bottlenecks (CPU/GPU utilization, kernel execution time). This PR integrates PyTorch Profiler natively to provide a user-friendly profiling experience.
## Modifications
1. **ModelRunner**: Added `enable_profiling` and `profiling_output_dir` arguments.
2. **Profiler Logic**: Implemented a non-intrusive profiler wrapper in `ModelRunner`.
   - Uses a manual lifecycle management (`start()`/`step()`) to avoid Kineto state errors.
   - Supports multi-GPU (Tensor Parallel) setups by appending `rank` to trace filenames.
   - Uses a default schedule (`wait=1, warmup=1, active=3, repeat=1`) to automatically capture the initial steps of inference without generating oversized files.
3. **Docs**: Updated `README.md` with usage instructions.
## Usage
Enable profiling during LLM initialization:
```python
from nanovllm import LLM
llm = LLM(
    model="Qwen/Qwen2.5-0.5B-Instruct",
    enable_profiling=True,
    profiling_output_dir="./profiler_logs"
)
# Run inference normally
# Profiler will automatically capture traces during the first few 
This pull request adds support for profiling tensor parallel inference with PyTorch's profiler, enabling detailed performance tracing across processes. Profiling can be enabled via a new flag, and traces are saved per process for analysis with TensorBoard or Perfetto. The implementation ensures profiling only captures inference (not initialization), and is integrated into both the `LLMEngine` and `ModelRunner` classes.

**Profiling support and documentation:**

* Added new `enable_profiling` and `profiling_output_dir` parameters to the `LLMEngine` and `ModelRunner` classes, allowing users to enable and configure PyTorch profiler output for each process. [[1]](diffhunk://#diff-bd3e2cd29a4c19008001c7cec119f8c19f9a78901ebce5d0212037195a01982eL17-R17) [[2]](diffhunk://#diff-bd3e2cd29a4c19008001c7cec119f8c19f9a78901ebce5d0212037195a01982eL26-R30) [[3]](diffhunk://#diff-b952226638660ed1016755ade81f50ce6b99c7484815105090b654cf4a62d396L17-R29) [[4]](diffhunk://#diff-b952226638660ed1016755ade81f50ce6b99c7484815105090b654cf4a62d396R46-R49)
* Implemented `_setup_profiler` method in `ModelRunner` to configure and start the PyTorch profiler, saving traces per rank for later analysis. Profiler is started lazily on first inference to avoid capturing initialization overhead. [[1]](diffhunk://#diff-b952226638660ed1016755ade81f50ce6b99c7484815105090b654cf4a62d396R59-R96) [[2]](diffhunk://#diff-b952226638660ed1016755ade81f50ce6b99c7484815105090b654cf4a62d396R255-R278)
* Updated the `exit` method in `ModelRunner` to ensure the profiler is properly stopped when the process exits.
* Added a new "Profiling" section to the `README.md` with usage instructions and analysis tips for the generated traces.