### PR TITLE
fix: pass rope_scaling=None for Qwen3 to avoid unhashable dict error

### DIFF
--- a/nanovllm/models/qwen3.py
+++ b/nanovllm/models/qwen3.py
@@ -132,7 +132,9 @@ class Qwen3DecoderLayer(nn.Module):
             qkv_bias=getattr(config, 'attention_bias', True),
             head_dim=getattr(config, 'head_dim', None),
             rope_theta=getattr(config, "rope_theta", 1000000),
-            rope_scaling=getattr(config, "rope_scaling", None),
+            rope_scaling=None,
+            # RoPE scaling is not implemented yet in nano-vllm rotary_embedding.get_rope,
+            # so pass None explicitly to avoid unhashable dict errors with newer transformers.
         )
         self.mlp = Qwen3MLP(
             hidden_size=config.hidden_size,


### PR DESCRIPTION
## Summary

This PR fixes a runtime error when loading Qwen3 models with newer versions of transformers(>5).

## Problem

Qwen3Attention forwards config.rope_scaling into get_rope(...), but get_rope() does not currently implement RoPE scaling and assumes rope_scaling is None.

In newer transformers versions, config.rope_scaling may be parsed as a dict, which causes:

TypeError: unhashable type: 'dict'

because get_rope() is cached with lru_cache.

## Fix

Pass rope_scaling=None explicitly in Qwen3Attention.

This keeps behavior aligned with the current implementation status and avoids the runtime error without changing existing RoPE logic.

Fixes #189