### PR TITLE
fix(engine): resolve crash on fully cached (100% match) prompt via L-1 fallback strategy

### DIFF
--- a/nanovllm/engine/model_runner.py
+++ b/nanovllm/engine/model_runner.py
@@ -134,9 +134,15 @@ class ModelRunner:
         block_tables = None
         for seq in seqs:
             seqlen = len(seq)
-            input_ids.extend(seq[seq.num_cached_tokens:])
-            positions.extend(list(range(seq.num_cached_tokens, seqlen)))
-            seqlen_q = seqlen - seq.num_cached_tokens
+
+            is_fully_cached = (seq.num_cached_tokens == seqlen)
+            num_cached_tokens = seq.num_cached_tokens
+            if is_fully_cached:
+                num_cached_tokens -= 1
+
+            input_ids.extend(seq[num_cached_tokens:])
+            positions.extend(list(range(num_cached_tokens, seqlen)))
+            seqlen_q = seqlen - num_cached_tokens
             seqlen_k = seqlen
             cu_seqlens_q.append(cu_seqlens_q[-1] + seqlen_q)
             cu_seqlens_k.append(cu_seqlens_k[-1] + seqlen_k)
@@ -151,6 +157,9 @@ class ModelRunner:
                 else:
                     end = start + seq.last_block_num_tokens 
                 slot_mapping.extend(list(range(start, end)))
+            if is_fully_cached:
+                slot_mapping.append((seq.block_table[-1] + 1) * self.block_size - 1)
+
         if cu_seqlens_k[-1] > cu_seqlens_q[-1]:    # prefix cache
             block_tables = self.prepare_block_tables(seqs)
         input_ids = torch.tensor(input_ids, dtype=torch.int64, pin_memory=True).cuda(non_blocking=True)


### PR DESCRIPTION
**Root Cause:**
When a sequence is fully cached in the prefix cache (i.e., a 100% match where prompt length exactly equals `block_size`), `seq[seq.num_cached_tokens:]` results in an empty slice, and `max_seqlen_q` evaluates to 0. This immediately triggers a `CUDA error: invalid configuration argument` in `flash_attn_varlen_func` because a kernel cannot launch with a grid size of 0. 

Furthermore, even if this empty prefill were hypothetically bypassed (which would cause empty logits and skip `seq.append_token`), `seq.num_tokens` would remain unchanged. In the subsequent decode step, the engine would incorrectly enter the `len(seq) % self.block_size == 0` branch in `BlockManager`, triggering an `assert last_block.hash == -1` failure and crashing the engine logically.

**Solution:**
Implemented an explicit "L-1 fallback strategy" for fully cached sequences:
1. Introduced an `is_fully_cached` flag to explicitly handle the edge case.
2. If fully cached, `num_cached_tokens` is locally decremented by 1, forcing the engine to re-compute the very last token. This ensures the prefill phase yields a valid next token and properly advances the state machine.
3. Appended the exact physical slot mapping for this last token `((seq.block_table[-1] + 1) * self.block_size - 1)` after the original block allocation loop, leveraging the natural bypass of the `range()` function to keep the original logic untouched.

This minimally invasive patch fixes the crash while maintaining strict isolation from the sequence's physical state.