### PR TITLE
fix RowParallelLinear weight_loader crash when bias is enabled

### DIFF
--- a/nanovllm/layers/linear.py
+++ b/nanovllm/layers/linear.py
@@ -141,6 +141,10 @@ class RowParallelLinear(LinearBase):
 
     def weight_loader(self, param: nn.Parameter, loaded_weight: torch.Tensor):
         param_data = param.data
+        if param_data.dim() == 1:
+            # bias is not sharded in RowParallelLinear
+            param_data.copy_(loaded_weight)
+            return
         shard_size = param_data.size(self.tp_dim)
         start_idx = self.tp_rank * shard_size
         loaded_weight = loaded_weight.narrow(self.tp_dim, start_idx, shard_size)


### PR DESCRIPTION
## Problem

When `RowParallelLinear` has `bias=True`, calling `weight_loader` on the bias parameter crashes with `IndexError` because `param_data.size(self.tp_dim)` uses `tp_dim=1`, but the bias tensor is 1D (only has dim 0).

## Fix

Skip the sharding logic for 1D parameters (bias). In `RowParallelLinear`, the bias is replicated across all ranks (not sharded), and only rank 0 applies it in `forward()`. So the weight_loader should just copy the full loaded weight for bias.

Fixes #125