### PR TITLE
Fix RMSNorm fp32 input mutation

### DIFF
--- a/nanovllm/layers/layernorm.py
+++ b/nanovllm/layers/layernorm.py
@@ -21,7 +21,7 @@ class RMSNorm(nn.Module):
         orig_dtype = x.dtype
         x = x.float()
         var = x.pow(2).mean(dim=-1, keepdim=True)
-        x.mul_(torch.rsqrt(var + self.eps))
+        x = x * torch.rsqrt(var + self.eps)
         x = x.to(orig_dtype).mul_(self.weight)
         return x
 

--- a/test/test_layernorm.py
+++ b/test/test_layernorm.py
@@ -1,0 +1,23 @@
+import importlib.util
+from pathlib import Path
+
+import torch
+
+
+spec = importlib.util.spec_from_file_location(
+    "layernorm",
+    Path(__file__).parents[1] / "nanovllm" / "layers" / "layernorm.py",
+)
+layernorm = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(layernorm)
+RMSNorm = layernorm.RMSNorm
+
+
+def test_rms_norm_does_not_modify_fp32_input():
+    norm = RMSNorm(4)
+    x = torch.randn(2, 4, dtype=torch.float32)
+    expected = x.clone()
+
+    norm(x)
+
+    torch.testing.assert_close(x, expected)


### PR DESCRIPTION
Fixes #170.

RMSNorm.rms_forward used an in-place mul_ after x.float(). When the input is already fp32, x.float() returns the original tensor, so the in-place normalization mutates hidden_states and corrupts the residual path.

This changes the scaling step to allocate a normalized tensor instead of mutating the input, and adds a regression test for fp32 inputs.

Testing:
- Attempted: uv run python -m pytest test/test_layernorm.py
- Blocked locally by Windows triton wheel incompatibility, WSL flash-attn build isolation, and later CPU torch dependency download timeout.
