### PR TITLE
fix(scheduler): recalculate num_tokens after allocate to prevent IndexError at model_runner:155

### DIFF
--- a/nanovllm/engine/scheduler.py
+++ b/nanovllm/engine/scheduler.py
@@ -28,14 +28,25 @@ class Scheduler:
         # prefill
         while self.waiting and len(scheduled_seqs) < self.max_num_seqs:
             seq = self.waiting[0]
-            num_tokens = max(seq.num_tokens - seq.num_cached_tokens, 1)
             remaining = self.max_num_batched_tokens - num_batched_tokens
-            if remaining == 0 or (not seq.block_table and not self.block_manager.can_allocate(seq)):    # no budget
+            if remaining == 0 or (not seq.block_table and not self.block_manager.can_allocate(seq)):
                 break
-            if remaining < num_tokens and scheduled_seqs:    # only allow chunked prefill for the first seq
-                break
+
             if not seq.block_table:
                 self.block_manager.allocate(seq)
+
+            # Re-calculate num_tokens after allocate(), as prefix caching may update 
+            # seq.num_cached_tokens during the allocation process.
+            #
+            # Using an outdated num_cached_tokens would overestimate num_scheduled_tokens, 
+            # leading to an inflated 'end' and 'end_block' in prepare_prefill (model_runner.py). 
+            # This results in an 'index out of range' at line 155 when accessing 
+            # seq.block_table[i] beyond its actual physical allocation.
+            num_tokens = max(seq.num_tokens - seq.num_cached_tokens, 1)
+
+            if remaining < num_tokens and scheduled_seqs:  # only allow chunked prefill for the first seq
+                break
+
             seq.num_scheduled_tokens = min(num_tokens, remaining)
             if seq.num_scheduled_tokens == num_tokens:
                 seq.status = SequenceStatus.RUNNING
@@ -43,6 +54,7 @@ class Scheduler:
                 self.running.append(seq)
             scheduled_seqs.append(seq)
             num_batched_tokens += seq.num_scheduled_tokens
+
         if scheduled_seqs:
             return scheduled_seqs, True
 


### PR DESCRIPTION
## Fix: IndexError in model_runner by re-ordering allocation logic

### Problem
A `list index out of range` occurs at `model_runner.py:155` during prefill when Prefix Caching is enabled.

*(Note: The traceback shows line 175 because I manually re-implemented the codebase for this project, leading to different line numbering. However, this fix addresses the logic corresponding to line 155 in the official repository.)*

``` bash
six@b68c2e9af1fa:~/projects/vllm-gpt2$ uv run python -m bench
Generating: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.18s/it, Prefill=3tok/s, Decode=319tok/s]
[rank0]: Traceback (most recent call last):
[rank0]:   File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
[rank0]:     return _run_code(code, main_globals, None,
[rank0]:   File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
[rank0]:     exec(code, run_globals)
[rank0]:   File "/home/liujiang/projects/vllm-gpt2/bench.py", line 33, in <module>
[rank0]:     main()
[rank0]:   File "/home/liujiang/projects/vllm-gpt2/bench.py", line 25, in main
[rank0]:     llm.generate(prompt_token_ids, sampling_params, use_tqdm=False)
[rank0]:   File "/home/liujiang/projects/vllm-gpt2/src/engine/llm_engine.py", line 74, in generate
[rank0]:     output, num_tokens = self.step()
[rank0]:   File "/home/liujiang/projects/vllm-gpt2/src/engine/llm_engine.py", line 51, in step
[rank0]:     token_ids = self.model_runner.call("run", seqs, is_prefill)
[rank0]:   File "/home/liujiang/projects/vllm-gpt2/src/engine/model_runner.py", line 94, in call
[rank0]:     return method(*args)
[rank0]:   File "/home/liujiang/projects/vllm-gpt2/src/engine/model_runner.py", line 306, in run
[rank0]:     input_ids, positions = self.prepare_prefill(seqs) if is_prefill else self.prepare_decode(seqs)
[rank0]:   File "/home/liujiang/projects/vllm-gpt2/src/engine/model_runner.py", line 175, in prepare_prefill
[rank0]:     slot_offset = seq.block_table[i] * self.block_size
[rank0]: IndexError: list index out of range
```

### Root Cause
In `scheduler.py`, `num_scheduled_tokens` was calculated **before** `block_manager.allocate(seq)`. 
- If `allocate()` triggers a prefix cache hit, `num_cached_tokens` increases.
- Using the stale (smaller) cache count leads to an **overestimated** `num_scheduled_tokens`.
- In `model_runner.py`, this inflated length causes `end` and `end_block` to exceed the actual bounds of `seq.block_table`.

### Fix
Re-ordered the logic in `scheduler.py`:
1. Call `allocate(seq)` first to update the cache state.
2. Calculate `num_tokens` and `num_scheduled_tokens` afterward.
