### PR TITLE
fix(block_manager): prevent in-flight prefix cache hits within same prefill batch

### DIFF
--- a/nanovllm/engine/block_manager.py
+++ b/nanovllm/engine/block_manager.py
@@ -12,6 +12,7 @@ class Block:
         self.ref_count = 0
         self.hash = -1
         self.token_ids = []
+        self.cache_ready = False
 
     def update(self, hash: int, token_ids: list[int]):
         self.hash = hash
@@ -21,6 +22,7 @@ class Block:
         self.ref_count = 1
         self.hash = -1
         self.token_ids = []
+        self.cache_ready = False
 
 
 class BlockManager:
@@ -64,7 +66,8 @@ class BlockManager:
             token_ids = seq.block(i)
             h = self.compute_hash(token_ids, h) if len(token_ids) == self.block_size else -1
             block_id = self.hash_to_block_id.get(h, -1)
-            if block_id == -1 or self.blocks[block_id].token_ids != token_ids:
+            block = self.blocks[block_id] if block_id != -1 else None
+            if (block_id == -1 or block.token_ids != token_ids or not block.cache_ready):
                 cache_miss = True
             if cache_miss:
                 block_id = self.free_block_ids[0]
@@ -107,6 +110,12 @@ class BlockManager:
             prefix = self.blocks[block_table[-2]].hash if len(block_table) > 1 else -1
             h = self.compute_hash(token_ids, prefix)
             last_block.update(h, token_ids)
+            last_block.cache_ready = True
             self.hash_to_block_id[h] = last_block.block_id
         else:
             assert last_block.hash == -1
+
+    def mark_blocks_ready(self, seq: Sequence, num_ready_tokens: int):
+        num_ready_blocks = num_ready_tokens // self.block_size
+        for i in range(num_ready_blocks):
+            self.blocks[seq.block_table[i]].cache_ready = True

--- a/nanovllm/engine/scheduler.py
+++ b/nanovllm/engine/scheduler.py
@@ -72,6 +72,7 @@ class Scheduler:
         for seq, token_id in zip(seqs, token_ids):
             if is_prefill:
                 seq.num_cached_tokens = min(seq.num_cached_tokens + seq.num_scheduled_tokens, seq.num_tokens)
+                self.block_manager.mark_blocks_ready(seq, seq.num_cached_tokens)
                 if seq.num_cached_tokens < seq.num_tokens or seq.num_completion_tokens > 0:    # chunked prefill or re prefill after preemption
                     seq.num_scheduled_tokens = 0
                     continue


### PR DESCRIPTION
## Problem

Closes #208.

When the scheduler fills a prefill batch with multiple sequences, it calls
`block_manager.allocate()` for each sequence in order.  Each call registers
newly-allocated blocks in `hash_to_block_id` immediately.  A subsequent
sequence in the **same batch** can then look up those hashes, find matching
`token_ids`, and count the blocks as prefix-cache hits — even though the GPU
hasn't computed the KV cache for those blocks yet.

This leads to:
- Incorrect `num_cached_tokens` (over-counted)
- Wrong `num_scheduled_tokens` in the batch
- Potential `IndexError` at `model_runner` line 155

## Fix

Add a `cache_ready: bool` flag to `Block` (default `False`):

- `allocate()` now requires `block.cache_ready == True` before treating a
  hash match as a prefix-cache hit.  Newly-allocated in-flight blocks have
  `cache_ready = False` and are never counted as hits within the same batch.
- `Scheduler.postprocess()` calls `block_manager.mark_blocks_ready(seq,
  num_cached_tokens)` after each prefill step, setting `cache_ready = True`
  on all fully-computed blocks.
- `may_append()` sets `cache_ready = True` when a decode step completes a
  full block.
- `Block.reset()` sets `cache_ready = False` so recycled blocks start clean.

## Test plan
- [ ] Multi-sequence prefill batch with shared long prefix: each sequence
  gets the correct `num_cached_tokens` (only hits from previous batches)
- [ ] Single-sequence prefill: unchanged behaviour
- [ ] Chunked prefill across multiple steps: blocks become ready
  incrementally
- [ ] Decode step that fills a block: block becomes `cache_ready` via
  `may_append()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)