### PR TITLE
fix(model_runner): correct seqlen_k to chunk boundary in prepare_prefill

### DIFF
--- a/nanovllm/engine/model_runner.py
+++ b/nanovllm/engine/model_runner.py
@@ -139,8 +139,8 @@ class ModelRunner:
             seqlen = len(seq)
             start = min(seq.num_cached_tokens, seqlen - 1)
             seqlen_q = seq.num_scheduled_tokens
-            seqlen_k = seqlen
             end = start + seqlen_q
+            seqlen_k = end
             input_ids.extend(seq[start:end])
             positions.extend(range(start, end))
             cu_seqlens_q.append(cu_seqlens_q[-1] + seqlen_q)


### PR DESCRIPTION
## Problem

In ,  is assigned the **full sequence length** () regardless of the current chunk's position:

```python
# Before (incorrect)
seqlen_k = seqlen          # full sequence length
end = start + seqlen_q
```

During **Chunked Prefill** (), this makes the attention kernel read KV cache slots that haven't been written yet — causing illegal memory access or incorrect results (as noted in #212, the bug is masked only because chunked prefill rarely triggers in the baseline configuration).

## Fix

Reorder the two statements so `end` is computed first, then use it for `seqlen_k`:

```python
# After (correct)
end = start + seqlen_q
seqlen_k = end             # = start + seqlen_q (chunk boundary only)
```

This ensures the attention kernel attends only to the tokens processed so far, consistent with the KV slots actually populated in the block table.

When there is no chunking (`seqlen_q == seqlen - start`), `end == seqlen` so behaviour is identical to before.

Fixes #212. Thanks to @DestineG for identifying the root cause and providing a reference implementation.