### PR TITLE
fix: normalize legacy rope_scaling to rope_parameters

### DIFF
--- a/nanovllm/config.py
+++ b/nanovllm/config.py
@@ -3,6 +3,26 @@ from dataclasses import dataclass
 from transformers import AutoConfig
 
 
+def normalize_rope_config(hf_config: AutoConfig) -> dict:
+    # transformers >= v5.0.0 : rope_parameters
+    if hasattr(hf_config, "rope_parameters") and hf_config.rope_parameters is not None:
+        return hf_config.rope_parameters
+
+    # transformers < v5.0.0 : rope_theta and rope_scaling
+    rope_parameters = {}
+    rope_theta = getattr(hf_config, "rope_theta", None)
+    if rope_theta is not None:
+        rope_parameters["rope_theta"] = rope_theta
+
+    rope_scaling = getattr(hf_config, "rope_scaling", None)
+    rope_parameters.setdefault("rope_type", "default")
+    if rope_scaling is not None:
+        rope_parameters.update(dict(rope_scaling))
+        rope_parameters["rope_type"] = rope_parameters.pop("type", "default")
+
+    return rope_parameters
+
+
 @dataclass(slots=True)
 class Config:
     model: str
@@ -22,4 +42,5 @@ class Config:
         assert self.kvcache_block_size % 256 == 0
         assert 1 <= self.tensor_parallel_size <= 8
         self.hf_config = AutoConfig.from_pretrained(self.model)
+        self.hf_config.rope_parameters = normalize_rope_config(self.hf_config)
         self.max_model_len = min(self.max_model_len, self.hf_config.max_position_embeddings)

--- a/nanovllm/layers/rotary_embedding.py
+++ b/nanovllm/layers/rotary_embedding.py
@@ -54,6 +54,10 @@ def get_rope(
     rotary_dim: int,
     max_position: int,
     base: float,
+    type: str = "default",
 ):
-    rotary_emb = RotaryEmbedding(head_size, rotary_dim, max_position, base)
-    return rotary_emb
+    if type == "default":
+        rotary_emb = RotaryEmbedding(head_size, rotary_dim, max_position, base)
+        return rotary_emb
+
+    raise NotImplementedError(f"Unsupported rope_type: {type!r}")

--- a/nanovllm/models/qwen3.py
+++ b/nanovllm/models/qwen3.py
@@ -23,7 +23,7 @@ class Qwen3Attention(nn.Module):
         rms_norm_eps: float = 1e-06,
         qkv_bias: bool = False,
         rope_theta: float = 10000,
-        rope_scaling: dict | None = None,
+        rope_type: str = "default",
     ) -> None:
         super().__init__()
         tp_size = dist.get_world_size()
@@ -51,13 +51,12 @@ class Qwen3Attention(nn.Module):
             hidden_size,
             bias=False,
         )
-        if isinstance(rope_scaling, dict):
-            rope_theta = rope_scaling.get("rope_theta", rope_theta)
         self.rotary_emb = get_rope(
             self.head_dim,
             rotary_dim=self.head_dim,
             max_position=max_position,
             base=rope_theta,
+            type=rope_type,
         )
         self.attn = Attention(
             self.num_heads,
@@ -124,6 +123,7 @@ class Qwen3DecoderLayer(nn.Module):
         config: Qwen3Config,
     ) -> None:
         super().__init__()
+        rope_parameters = getattr(config, "rope_parameters", None) or {}
         self.self_attn = Qwen3Attention(
             hidden_size=config.hidden_size,
             num_heads=config.num_attention_heads,
@@ -132,8 +132,8 @@ class Qwen3DecoderLayer(nn.Module):
             rms_norm_eps=config.rms_norm_eps,
             qkv_bias=getattr(config, 'attention_bias', True),
             head_dim=getattr(config, 'head_dim', None),
-            rope_theta=getattr(config, "rope_theta", 1000000),
-            rope_scaling=getattr(config, "rope_scaling", None),
+            rope_theta=rope_parameters.get("rope_theta", 1000000),
+            rope_type=rope_parameters.get("rope_type", "default"),
         )
         self.mlp = Qwen3MLP(
             hidden_size=config.hidden_size,


### PR DESCRIPTION
# PR: Normalize Qwen3 RoPE config across Transformers versions

## Summary

This PR adds a RoPE config normalization step in `nanovllm/config.py` so that Nano vLLM can consume Qwen3 configs from different `transformers` versions (both >5 and <5) through a unified `rope_parameters` interface.

The main goal is to avoid runtime failures like:

```text
self.rotary_emb = get_rope(
    self.head_dim,
    rotary_dim=self.head_dim,
    max_position=max_position,
    base=rope_theta,
    type=rope_type,
)
TypeError: unhashable type: 'dict'
```

## Background

`nanovllm/models/qwen3.py` reads RoPE settings from `config.rope_theta` and `config.rope_scaling` , but recent `transformers` releases may expose RoPE-related fields differently:

- Newer schema: `rope_parameters`
```
{
  "rope_theta": 1000000,
  "rope_scaling": null
}
```
- Older schema: `rope_theta` and `rope_scaling`
```
{
  "rope_parameters":{
    "rope_theta": 1000000
    "rope_type": "default",
  }
}
```
In versions of `transformers` > 5, `rope_scaling` is an alias of `rope_parameters`, which means it is a dict. As a result, a dict is passed into `get_rope(...)`, causing `lru_cache` to raise `TypeError: unhashable type: 'dict'`.


## Changes

This PR introduces a normalization helper in `nanovllm/config.py` and applies it immediately after `AutoConfig.from_pretrained(...)`.

Normalization behavior:

- If `hf_config.rope_parameters` already exists, keep it unchanged.
- Otherwise, build `rope_parameters` from legacy fields:
  - `rope_theta`
  - `rope_scaling`
- Normalize the legacy key rename:
  - `rope_scaling.type` -> `rope_type`
- Ensure a default fallback:
  - `rope_type = "default"`

After normalization, downstream model code can consistently read:

```python
config.rope_parameters
```

without needing version-specific branching.

## Validation

This change has been validated with `transformers` 4.56.0 and 5.6.0.

## Why this approach

- Reserves compatibility with newer `transformers` versions that already expose `rope_parameters`.
- Normalizes RoPE inputs before calling `get_rope(...)`, which makes it easier to extend the same interface to other models in the future.


