### PR TITLE
fix(model_runner): all_reduce num_kvcache_blocks to MIN across TP ranks

### DIFF
--- a/nanovllm/engine/model_runner.py
+++ b/nanovllm/engine/model_runner.py
@@ -111,6 +111,12 @@ class ModelRunner:
         head_dim = getattr(hf_config, "head_dim", hf_config.hidden_size // hf_config.num_attention_heads)
         block_bytes = 2 * hf_config.num_hidden_layers * self.block_size * num_kv_heads * head_dim * hf_config.dtype.itemsize
         config.num_kvcache_blocks = int(total * config.gpu_memory_utilization - used - peak + current) // block_bytes
+        if self.world_size > 1:
+            # Under TP all ranks must agree on the same block count so block IDs are
+            # consistent.  Take the minimum to avoid over-allocating on any rank.
+            t = torch.tensor(config.num_kvcache_blocks, dtype=torch.int64, device="cuda")
+            dist.all_reduce(t, op=dist.ReduceOp.MIN)
+            config.num_kvcache_blocks = int(t.item())
         assert config.num_kvcache_blocks > 0
         self.kv_cache = torch.empty(2, hf_config.num_hidden_layers, config.num_kvcache_blocks, self.block_size, num_kv_heads, head_dim)
         layer_id = 0


### PR DESCRIPTION
## Problem

Fixes #187.

Under tensor parallelism, each `ModelRunner` instance independently estimates `config.num_kvcache_blocks` from its own GPU memory snapshot (free memory, peak allocations, etc.). Because different ranks can have slightly different memory states at the time of estimation, they can arrive at **different** block counts:

```
rank 0: num_kvcache_blocks = 512
rank 1: num_kvcache_blocks = 510
```

The `BlockManager` on rank 0 will allocate block IDs up to 511, but rank 1's KV-cache only has indices 0–509. When a sequence is assigned block 510 or 511, rank 1's cache lookup silently goes out of range.

## Fix

After the local estimate, synchronize `num_kvcache_blocks` across all TP ranks with a **MIN all-reduce**, so every rank allocates exactly the same number of blocks:

```python
if self.world_size > 1:
    t = torch.tensor(config.num_kvcache_blocks, dtype=torch.int64, device="cuda")
    dist.all_reduce(t, op=dist.ReduceOp.MIN)
    config.num_kvcache_blocks = int(t.item())
```

MIN ensures we never over-allocate relative to the most-constrained rank, and since the all-reduce completes before `kv_cache` is allocated, all ranks allocate the same tensor size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)