### PR TITLE
fix(model_runner): cover all decode batch sizes in CUDA graph buckets

### DIFF
--- a/nanovllm/engine/model_runner.py
+++ b/nanovllm/engine/model_runner.py
@@ -232,7 +232,11 @@ class ModelRunner:
         context_lens = torch.zeros(max_bs, dtype=torch.int32)
         block_tables = torch.zeros(max_bs, max_num_blocks, dtype=torch.int32)
         outputs = torch.zeros(max_bs, hf_config.hidden_size)
-        self.graph_bs = [1, 2, 4, 8] + list(range(16, max_bs + 1, 16))
+        # Always include max_bs and never exceed it: otherwise a decode batch
+        # whose size falls in the gap between the largest captured bucket and
+        # max_bs would raise StopIteration in run_model. Triggers whenever
+        # max_num_seqs is not a multiple of 16 (or smaller than 16), e.g. 12 or 100.
+        self.graph_bs = sorted({b for b in (1, 2, 4, 8) if b <= max_bs} | set(range(16, max_bs + 1, 16)) | {max_bs})
         self.graphs = {}
         self.graph_pool = None
 


### PR DESCRIPTION
## Bug

`ModelRunner.capture_cudagraph` builds the CUDA graph batch-size buckets as:

```python
self.graph_bs = [1, 2, 4, 8] + list(range(16, max_bs + 1, 16))
```

where `max_bs = min(config.max_num_seqs, 512)`. The largest bucket is therefore the largest multiple of 16 that is ≤ `max_bs`. Whenever `max_num_seqs` is **not** a multiple of 16 (or is smaller than 16), the buckets do **not** cover `max_bs`. Any decode batch with a size in that gap then crashes in `run_model`:

```python
graph = self.graphs[next(x for x in self.graph_bs if x >= bs)]
# StopIteration when no bucket is large enough
```

## Repro (pure Python, no GPU needed)

```python
def buggy(max_bs):
    return [1, 2, 4, 8] + list(range(16, max_bs + 1, 16))

for max_bs in (12, 100, 200, 300):
    g = buggy(max_bs)
    print(f"max_num_seqs={max_bs}: largest bucket = {g[-1]}; "
          f"decode bs={max_bs} would StopIteration")
# max_num_seqs=12:  largest bucket = 8;   decode bs=12 would StopIteration
# max_num_seqs=100: largest bucket = 96;  decode bs=100 would StopIteration
# max_num_seqs=200: largest bucket = 192; decode bs=200 would StopIteration
# max_num_seqs=300: largest bucket = 288; decode bs=300 would StopIteration
```

The default `max_num_seqs=512` happens to be aligned, so the bug stays latent until a user lowers the value (e.g. on smaller GPUs) or picks a non-multiple-of-16 cap.

## Secondary issue (also fixed)

The current construction also produces buckets **larger than** `max_bs` when `max_bs < 8` (e.g. `max_bs=5` → `[1, 2, 4, 8]`). Capture then runs through `bs=8` against tensors sized `max_bs=5`, capturing a graph that is silently keyed under the wrong batch size. Restricting buckets to `≤ max_bs` removes that footgun too.

## Fix

```python
self.graph_bs = sorted(
    {b for b in (1, 2, 4, 8) if b <= max_bs}
    | set(range(16, max_bs + 1, 16))
    | {max_bs}
)
```

Invariants:

- `max_bs` is always present (no StopIteration for any decode bs in `[1, max_bs]`).
- All buckets satisfy `1 <= bucket <= max_bs`.
- `max_num_seqs=512` (default) is unchanged: still the same 36 buckets ending at 512.

## Verification

```python
def fixed(max_bs):
    return sorted({b for b in (1,2,4,8) if b <= max_bs}
                  | set(range(16, max_bs+1, 16)) | {max_bs})

for max_bs in (3, 5, 8, 12, 16, 17, 100, 256, 512):
    g = fixed(max_bs)
    assert max(g) == max_bs and all(b <= max_bs for b in g)
    for bs in range(1, max_bs+1):                # never StopIterates
        assert next(x for x in g if x >= bs) >= bs
```

```
max_bs=  3: [1, 2, 3]
max_bs=  5: [1, 2, 4, 5]
max_bs=  8: [1, 2, 4, 8]
max_bs= 12: [1, 2, 4, 8, 12]
max_bs= 16: [1, 2, 4, 8, 16]
max_bs= 17: [1, 2, 4, 8, 16, 17]
max_bs=100: [1, 2, 4, 8, 16, 32, 48, 64, 80, 96, 100]
max_bs=256: [1, 2, 4, 8, 16, 32, 48, 64, 80, 96, 112, ..., 256]
max_bs=512: [1, 2, 4, 8, 16, 32, 48, 64, 80, 96, 112, ..., 512]
```

## Scope

One-line change in `nanovllm/engine/model_runner.py`, plus a short comment explaining the invariants. No behavior change for the default `max_num_seqs=512`.

---
🤖 Drafted with [Claude Code](https://claude.com/claude-code)