### PR TITLE
fix: remove early exit in re-prefill to prevent KV cache AssertionError

### DIFF
--- a/nanovllm/engine/scheduler.py
+++ b/nanovllm/engine/scheduler.py
@@ -84,7 +84,7 @@ class Scheduler:
         for seq, token_id in zip(seqs, token_ids):
             if is_prefill:
                 seq.num_cached_tokens = min(seq.num_cached_tokens + seq.num_scheduled_tokens, seq.num_tokens)
-                if seq.num_cached_tokens < seq.num_tokens or seq.num_completion_tokens > 0:    # chunked prefill or re prefill after preemption
+                if seq.num_cached_tokens < seq.num_tokens:    # chunked prefill
                     seq.num_scheduled_tokens = 0
                     continue
             seq.append_token(token_id)


### PR DESCRIPTION
## fix: remove early exit in re-prefill to prevent KV cache AssertionError


### Description
This PR fixes a bug that causes an `AssertionError` in the KV cache block manager when a sequence is preempted and subsequently re-prefilled. 

### Root Cause
In `nanovllm/engine/scheduler.py`, the `postprocess` function contained an early exit condition (`or seq.num_completion_tokens > 0`) intended for re-prefill after preemption. When a preempted sequence was re-prefilled, this `continue` statement incorrectly skipped `seq.append_token(token_id)`.

This created a severe state mismatch:
1. The sequence length failed to increment.
2. The newly computed token logit from the re-prefill forward pass was discarded (leading to a redundant computation in the next decode step).
3. During the subsequent decode step, `may_append` in `block_manager.py` used the stale sequence length, breaking the modulo logic used for block allocation.

### Example: The 257-Token Edge Case
To illustrate exactly how this crashes the engine, consider a sequence with a block size of 256:
* **Preemption:** Suppose a sequence is preempted at exactly **257 tokens** (1 full block + 1 token in the new block).
* **Re-prefill Allocation:** When scheduled again, `allocate` creates 2 blocks. Since the second block only has 1 token, it is not full, so its hash remains `-1`. 
* **The Crash (Before):** The `continue` statement prevents the newly generated 258th token from being appended. The sequence length stays at 257. In the next decode step, `may_append` evaluates `257 % 256 == 1`. It wrongly assumes a block boundary was just crossed and expects the block to be fully hashed (`assert last_block.hash != -1`). However, the block only has 1 token (hash `-1`), instantly triggering the crash.
* **The Fix (After):** The re-prefill properly appends the new token. The length becomes 258. In the next decode step, `258 % 256 == 2`, cleanly passing the `else: assert last_block.hash == -1` check.

### Solution
Removed the `or seq.num_completion_tokens > 0` check. 

By removing this, re-prefill now behaves identically to standard prefill. It properly appends the newly computed token, correctly increments the sequence length, and keeps the engine's state machine perfectly aligned with the physical block allocations in the block manager. As a bonus, this completely eliminates the redundant forward pass for that specific token.

### Testing & Validation
I have tested this locally by running `python bench.py`. With this fix, the benchmark now completes successfully without triggering the previous KV cache `AssertionError`.

**Before:**
```text
Generating: 100%|████████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.36s/it, Prefill=4tok/s, Decode=93tok/s]
[rank0]: Traceback (most recent call last):
[rank0]:   File "/root/nano-vllm/bench.py", line 32, in <module>
...
[rank0]:   File "/root/nano-vllm/nanovllm/engine/block_manager.py", line 100, in may_append
[rank0]:     assert last_block.hash != -1
[rank0]:             ^^^^^^^^^^^^^^^^^^^^^
[rank0]: AssertionError
```

**After:**
```text
Generating: 100%|████████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.34s/it, Prefill=4tok/s, Decode=94tok/s]
Total: 133966tok, Time: 65.39s, Throughput: 2048.67tok/s
```