### PR TITLE
feat: support weightless RMSNorm for FlashNorm models

### DIFF
--- a/nanovllm/layers/layernorm.py
+++ b/nanovllm/layers/layernorm.py
@@ -8,10 +8,14 @@ class RMSNorm(nn.Module):
         self,
         hidden_size: int,
         eps: float = 1e-6,
+        has_weight: bool = True,
     ) -> None:
         super().__init__()
         self.eps = eps
-        self.weight = nn.Parameter(torch.ones(hidden_size))
+        if has_weight:
+            self.weight = nn.Parameter(torch.ones(hidden_size))
+        else:
+            self.register_parameter("weight", None)
 
     @torch.compile
     def rms_forward(
@@ -22,7 +26,9 @@ class RMSNorm(nn.Module):
         x = x.float()
         var = x.pow(2).mean(dim=-1, keepdim=True)
         x.mul_(torch.rsqrt(var + self.eps))
-        x = x.to(orig_dtype).mul_(self.weight)
+        x = x.to(orig_dtype)
+        if self.weight is not None:
+            x = x.mul_(self.weight)
         return x
 
     @torch.compile
@@ -36,7 +42,9 @@ class RMSNorm(nn.Module):
         residual = x.to(orig_dtype)
         var = x.pow(2).mean(dim=-1, keepdim=True)
         x.mul_(torch.rsqrt(var + self.eps))
-        x = x.to(orig_dtype).mul_(self.weight)
+        x = x.to(orig_dtype)
+        if self.weight is not None:
+            x = x.mul_(self.weight)
         return x, residual
 
     def forward(

--- a/nanovllm/models/qwen3.py
+++ b/nanovllm/models/qwen3.py
@@ -140,8 +140,9 @@ class Qwen3DecoderLayer(nn.Module):
             intermediate_size=config.intermediate_size,
             hidden_act=config.hidden_act,
         )
-        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        rms_norm_has_weight = getattr(config, "rms_norm_has_weight", True)
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps, has_weight=rms_norm_has_weight)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps, has_weight=rms_norm_has_weight)
 
     def forward(
         self,

--- a/nanovllm/models/qwen3.py
+++ b/nanovllm/models/qwen3.py
@@ -140,9 +140,9 @@ class Qwen3DecoderLayer(nn.Module):
             intermediate_size=config.intermediate_size,
             hidden_act=config.hidden_act,
         )
-        rms_norm_has_weight = getattr(config, "rms_norm_has_weight", True)
-        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps, has_weight=rms_norm_has_weight)
-        self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps, has_weight=rms_norm_has_weight)
+        has_weight = not getattr(config, "flash_norm", False)
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps, has_weight=has_weight)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps, has_weight=has_weight)
 
     def forward(
         self,


### PR DESCRIPTION
Closes #220

## What

Adds a `has_weight` flag to `RMSNorm` so FlashNorm models can run without the pointless weight multiply.

FlashNorm folds the RMSNorm weights into the next linear layer at conversion time, so the resulting checkpoint doesn't have `input_layernorm.weight` or `post_attention_layernorm.weight` at all. nano-vllm currently always creates that weight param (defaults to ones) and multiplies by it every forward pass — wasted compute. This skips it when the weights aren't there.

Pre-converted models: https://huggingface.co/models?other=weightless-rmsnorm

## What changed

- `RMSNorm` now takes a `has_weight` param, defaults to `True` so nothing changes for existing models
- When `False`, weight is `None` and the multiply gets skipped in both `rms_forward` and `add_rms_forward`
- `Qwen3DecoderLayer` reads `flash_norm` from the HF config and passes it through
- `model.norm` and `q_norm`/`k_norm` are untouched — FlashNorm keeps those

## How to use

Drop `"flash_norm": true` into the model's `config.json`, that's it.