### PR TITLE
Fix prefix cache OOB in prepare_prefill when num_cached_tokens grows during allocate

### DIFF
--- a/nanovllm/engine/model_runner.py
+++ b/nanovllm/engine/model_runner.py
@@ -138,7 +138,7 @@ class ModelRunner:
         for seq in seqs:
             seqlen = len(seq)
             start = min(seq.num_cached_tokens, seqlen - 1)
-            seqlen_q = seq.num_scheduled_tokens
+            seqlen_q = min(seq.num_scheduled_tokens, seqlen - start)
             seqlen_k = seqlen
             end = start + seqlen_q
             input_ids.extend(seq[start:end])


### PR DESCRIPTION
## Bug
When prefix caching hits during `block_manager.allocate()`, `num_cached_tokens` can jump from 0 to N*block_size. But the scheduler already computed `num_scheduled_tokens` based on the old `num_cached_tokens=0` before calling `allocate()`. This causes `prepare_prefill` to compute `end = start + seqlen_q` exceeding `num_tokens`, leading to `block_table` index out of range.

## Reproduce
High concurrency (512 requests) + KV cache full + prefix cache hit → preempt → re-prefill → 100% crash with `IndexError: list index out of range` at `model_runner.py:155`.

## Fix
One line: clamp `seqlen_q` to not exceed remaining uncached tokens.
```diff
-            seqlen_q = seq.num_scheduled_tokens
+            seqlen_q = min(seq.num_scheduled_tokens, seqlen - start)
