### PR TITLE
fix(tp): acknowledge shm reads so rank0 cannot corrupt in-flight RPC (#246)

### DIFF
--- a/nanovllm/engine/llm_engine.py
+++ b/nanovllm/engine/llm_engine.py
@@ -21,14 +21,19 @@ class LLMEngine:
         Sequence.block_size = config.kvcache_block_size
         self.ps = []
         self.events = []
+        self.ack_events = []
         ctx = mp.get_context("spawn")
         for i in range(1, config.tensor_parallel_size):
             event = ctx.Event()
-            process = ctx.Process(target=ModelRunner, args=(config, i, event))
+            ack_event = ctx.Event()
+            # Pre-set so rank0 can write the first command before any read.
+            ack_event.set()
+            process = ctx.Process(target=ModelRunner, args=(config, i, event, ack_event))
             process.start()
             self.ps.append(process)
             self.events.append(event)
-        self.model_runner = ModelRunner(config, 0, self.events)
+            self.ack_events.append(ack_event)
+        self.model_runner = ModelRunner(config, 0, self.events, self.ack_events)
         self.tokenizer = AutoTokenizer.from_pretrained(config.model, use_fast=True)
         config.eos = self.tokenizer.eos_token_id
         self.scheduler = Scheduler(config)

--- a/nanovllm/engine/model_runner.py
+++ b/nanovllm/engine/model_runner.py
@@ -14,7 +14,7 @@ from nanovllm.utils.loader import load_model
 
 class ModelRunner:
 
-    def __init__(self, config: Config, rank: int, event: Event | list[Event]):
+    def __init__(self, config: Config, rank: int, event: Event | list[Event], ack_event: Event | list[Event]):
         self.config = config
         hf_config = config.hf_config
         self.block_size = config.kvcache_block_size
@@ -22,6 +22,7 @@ class ModelRunner:
         self.world_size = config.tensor_parallel_size
         self.rank = rank
         self.event = event
+        self.ack_event = ack_event
 
         dist.init_process_group("nccl", "tcp://localhost:2333", world_size=self.world_size, rank=rank)
         torch.cuda.set_device(rank)
@@ -71,10 +72,19 @@ class ModelRunner:
         n = int.from_bytes(self.shm.buf[0:4], "little")
         method_name, *args = pickle.loads(self.shm.buf[4:n+4])
         self.event.clear()
+        # Acknowledge that the payload has been fully read so rank0 may safely
+        # reuse the shared buffer for the next command.
+        self.ack_event.set()
         return method_name, args
 
     def write_shm(self, method_name, *args):
         assert self.world_size > 1 and self.rank == 0
+        # Wait until every worker has finished reading the previous command
+        # before overwriting the shared buffer; otherwise a worker still
+        # reading the old payload sees corrupted data (UnpicklingError).
+        for ack_event in self.ack_event:
+            ack_event.wait()
+            ack_event.clear()
         data = pickle.dumps([method_name, *args])
         n = len(data)
         self.shm.buf[0:4] = n.to_bytes(4, "little")


### PR DESCRIPTION
## Summary

Fixes #246.

In tensor-parallel mode (`tensor_parallel_size > 1`), rank0 dispatches method calls to worker ranks through a shared-memory buffer plus a per-worker `multiprocessing.Event`. The protocol only had a **forward** (rank0 → worker) notification: there was no acknowledgement that a worker had finished reading the previous command.

As a result rank0 could return from one `call()` and immediately `write_shm()` the next RPC, overwriting the shared buffer while a worker was still inside `pickle.loads(self.shm.buf[...])` for the previous command. That corrupts the payload (`_pickle.UnpicklingError`); once one worker rank dies, the surviving ranks hang in the next NCCL collective until timeout.

## Fix

Add a per-worker **acknowledgement** event that closes the handshake:

- `read_shm` (worker): after fully reading and unpickling the payload, `self.ack_event.set()`.
- `write_shm` (rank0): before overwriting the buffer, `wait()` + `clear()` every worker's ack event, so the buffer is only reused once **all** workers have consumed the previous command.
- The ack events are pre-set in `LLMEngine` so the very first command isn't blocked waiting on a read that hasn't happened yet.

This is the ping-pong the buffer needs: rank0 clears each ack **before** setting the forward event, and a worker sets its ack only **after** the read completes, so no signal is lost and no read races an overwrite. No change to the public `LLM`/`LLMEngine` API; only `ModelRunner`'s internal constructor gains an `ack_event` argument, and its sole caller (`LLMEngine`) is updated.

## Testing

- `python -m py_compile` on both changed modules.
- Handshake reasoning verified against the exit path (`call("exit")` still drains cleanly) and the bootstrap case (pre-set acks let the first `write_shm` proceed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
