### PR TITLE
Restore greedy sampling via temperature=0

### DIFF
--- a/nanovllm/layers/sampler.py
+++ b/nanovllm/layers/sampler.py
@@ -6,7 +6,8 @@ class Sampler(nn.Module):
 
     @torch.compile
     def forward(self, logits: torch.Tensor, temperatures: torch.Tensor):
-        logits = logits.float().div_(temperatures.unsqueeze(dim=1))
+        greedy_tokens = logits.argmax(dim=-1)
+        logits = logits.float().div_(temperatures.clamp_min(1e-10).unsqueeze(dim=1))
         probs = torch.softmax(logits, dim=-1)
         sample_tokens = probs.div_(torch.empty_like(probs).exponential_(1).clamp_min_(1e-10)).argmax(dim=-1)
-        return sample_tokens
+        return torch.where(temperatures == 0, greedy_tokens, sample_tokens)

--- a/nanovllm/sampling_params.py
+++ b/nanovllm/sampling_params.py
@@ -8,4 +8,4 @@ class SamplingParams:
     ignore_eos: bool = False
 
     def __post_init__(self):
-        assert self.temperature > 1e-10, "greedy sampling is not permitted"
+        assert self.temperature >= 0.0, "temperature must be non-negative"

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -1,0 +1,32 @@
+import importlib.util, pathlib, torch, pytest
+
+from nanovllm.sampling_params import SamplingParams
+
+_p = pathlib.Path(__file__).resolve().parents[1] / "nanovllm/layers/sampler.py"
+_s = importlib.util.spec_from_file_location("sampler", _p)
+_m = importlib.util.module_from_spec(_s); _s.loader.exec_module(_m)
+Sampler = _m.Sampler
+
+def test_temperature_zero_is_permitted():
+    SamplingParams(temperature=0.0)
+
+def test_negative_temperature_rejected():
+    with pytest.raises(AssertionError):
+        SamplingParams(temperature=-1.0)
+
+def test_greedy_is_argmax():
+    logits = torch.randn(8, 1000, dtype=torch.bfloat16)
+    out = Sampler()(logits.clone(), torch.zeros(8))
+    assert torch.equal(out, logits.argmax(-1))
+
+def test_mixed_batch_routes_per_row():
+    logits = torch.randn(6, 1000, dtype=torch.bfloat16)
+    temps = torch.tensor([0., 0.6, 0., 1.0, 0., 0.6])
+    out = Sampler()(logits.clone(), temps)
+    g = temps == 0
+    assert torch.equal(out[g], logits.argmax(-1)[g])
+
+def test_stochastic_path_is_not_constant():
+    logits = torch.randn(1, 1000, dtype=torch.bfloat16)
+    draws = {Sampler()(logits.clone(), torch.ones(1)).item() for _ in range(200)}
+    assert len(draws) > 1


### PR DESCRIPTION
## What

Restores greedy decoding: `temperature=0` now performs exact argmax sampling.
3 lines added to the sampler, 1 assert relaxed, tests included.

## Background

Greedy existed in the original sampler (`argmax` + `torch.where` routing) and was
removed in 6ef2a4f when the sampler was rewritten under `@torch.compile`, with the
`temperature > 1e-10` assert added as a guard. This PR restores the original design,
adapted to the compiled sampler:

- greedy candidate taken via `argmax` on raw logits (argmax is invariant to positive
  scaling, so this is the exact T→0 limit)
- `clamp_min(1e-10)` (out-of-place) guards the division for T=0 rows, replacing the
  transient inf/NaN lane the pre-6ef2a4f code masked away
- `torch.where(temperatures == 0, ...)` routes per row — mixed greedy/stochastic
  batches work, single compiled graph, no branching

## Why

T=0 is the standard API contract (vLLM / HF / OpenAI), required by common eval
harnesses, and useful wherever deterministic output matters.

## Validation (A100, Qwen3-0.6B, torch 2.10 + cu128 + flash-attn 2.8.1)

- **No regression with greedy unused**: bench.py (T=0.6): 8670/8687 tok/s on main vs
  8669/8654 on this branch (first run discarded as warmup) — delta −0.2%, equal to
  run-to-run variance. Expected: for T>0 the added ops draw no RNG, so the sampled
  stream is bit-identical to main.
- **Greedy vs HF transformers greedy decode**: 95/96 tokens exactly equal across
  3 prompts × 32 tokens. The single divergence is a bf16 near-tie (fp32 logit gap
  0.057 < one bf16 ulp at that magnitude, 0.125); a full-sequence HF forward over the
  same context ranks this branch's token first.
- Unit tests cover the T=0/argmax equality, mixed-batch routing, the stochastic path,
  and the params-level boundary (T=0 accepted, T<0 rejected).

Full benchmark scripts and raw outputs:
https://github.com/badle0/nano-vllm/tree/pr1-artifacts