### PR TITLE
feat: add Qwen3-MoE support with fused triton kernels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# Downloaded model weights
+/models/
+
 # C extensions
 *.so
 

--- a/docs/Moe.md
+++ b/docs/Moe.md
@@ -1,0 +1,18 @@
+#### 调用链
+vllm Version: 0.15.0
+vllm调用moe模型最简单的一个调用链，vllm版本不同会不太一样，也可以直接让codex直接分析整个调用过程。
+```mermaid
+flowchart TD
+    A[qwen3_moe.py] --> B[Qwen3MoeSparseMoeBlock]
+    B --> C[SharedFusedMoe]
+    C --> C1[FusedMoe]
+    C1 --> D[UnquantizedFusedMoEMethod]
+    D --> E[FusedMoEMethodBase]
+    E --> F[FusedMoEModularKernel]
+    F --> G[FusedMoEPrepareAndFinalize, FusedMoEPermuteExpertsUnpermute]
+    G --> H[FusedMoEPrepareAndFinalize]
+    G --> I[FusedMoEPermuteExpertsUnpermute]
+    H --> J[MoEPrepareAndFinalizeNoEP]
+    I --> K[TritonExperts]
+    K --> L[fused_moe_kernel]
+```

--- a/example_moe.py
+++ b/example_moe.py
@@ -1,0 +1,34 @@
+import os
+from nanovllm import LLM, SamplingParams
+from transformers import AutoTokenizer
+
+
+def main():
+
+    path = os.path.expanduser("/data/wxtang/model/models--yujiepan--qwen3-moe-tiny-random/snapshots/fb6c5ee2a2c19bd9aced6d9afd8a858966a7bb7e")
+    tokenizer = AutoTokenizer.from_pretrained(path)
+    llm = LLM(path, enforce_eager=True, tensor_parallel_size=1)
+
+    sampling_params = SamplingParams(temperature=0.6, max_tokens=256)
+    prompts = [
+        "introduce yourself",
+        "list all prime numbers within 100",
+    ]
+    prompts = [
+        tokenizer.apply_chat_template(
+            [{"role": "user", "content": prompt}],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        for prompt in prompts
+    ]
+    outputs = llm.generate(prompts, sampling_params)
+
+    for prompt, output in zip(prompts, outputs):
+        print("\n")
+        print(f"Prompt: {prompt!r}")
+        print(f"Completion: {output['text']!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/example_moe.py
+++ b/example_moe.py
@@ -5,7 +5,7 @@ from transformers import AutoTokenizer
 
 def main():
 
-    path = os.path.expanduser("/data/wxtang/model/models--yujiepan--qwen3-moe-tiny-random/snapshots/fb6c5ee2a2c19bd9aced6d9afd8a858966a7bb7e")
+    path = os.path.expanduser("/root/nano-vllm-kms/models/qwen3-moe-tiny-random")
     tokenizer = AutoTokenizer.from_pretrained(path)
     llm = LLM(path, enforce_eager=True, tensor_parallel_size=1)
 

--- a/nanovllm/engine/model_runner.py
+++ b/nanovllm/engine/model_runner.py
@@ -6,10 +6,9 @@ from multiprocessing.shared_memory import SharedMemory
 
 from nanovllm.config import Config
 from nanovllm.engine.sequence import Sequence
-from nanovllm.models.qwen3 import Qwen3ForCausalLM
 from nanovllm.layers.sampler import Sampler
 from nanovllm.utils.context import set_context, get_context, reset_context
-from nanovllm.utils.loader import load_model
+from nanovllm.utils.loader import load_model, load_model_arch_from_config
 
 
 class ModelRunner:
@@ -28,7 +27,8 @@ class ModelRunner:
         default_dtype = torch.get_default_dtype()
         torch.set_default_dtype(hf_config.dtype)
         torch.set_default_device("cuda")
-        self.model = Qwen3ForCausalLM(hf_config)
+        model_cls = load_model_arch_from_config(hf_config)
+        self.model = model_cls(hf_config)
         load_model(self.model, config.model)
         self.sampler = Sampler()
         self.warmup_model()
@@ -107,7 +107,7 @@ class ModelRunner:
         used = total - free
         peak = torch.cuda.memory_stats()["allocated_bytes.all.peak"]
         current = torch.cuda.memory_stats()["allocated_bytes.all.current"]
-        num_kv_heads = hf_config.num_key_value_heads // self.world_size
+        num_kv_heads = max(1, hf_config.num_key_value_heads // self.world_size)
         head_dim = getattr(hf_config, "head_dim", hf_config.hidden_size // hf_config.num_attention_heads)
         block_bytes = 2 * hf_config.num_hidden_layers * self.block_size * num_kv_heads * head_dim * hf_config.dtype.itemsize
         config.num_kvcache_blocks = int(total * config.gpu_memory_utilization - used - peak + current) // block_bytes

--- a/nanovllm/layers/fused_moe/fused_moe.py
+++ b/nanovllm/layers/fused_moe/fused_moe.py
@@ -1,0 +1,338 @@
+import nanovllm.layers.fused_moe.modular_kernel as mk
+import torch
+import torch.nn.functional as F
+import triton.language as tl
+import triton
+from nanovllm.utils.math_utils import round_up
+from nanovllm.layers.activation import SiluAndMul
+@triton.jit
+def fused_moe_triton_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    topk_weights_ptr,
+    sorted_token_ids_ptr,
+    expert_ids_ptr,
+    num_tokens_post_pad_ptr,
+    # 矩阵维度
+    N,
+    K,
+    EM,
+    num_valid_tokens,
+    # stride
+    stride_am,
+    stride_ak,
+    stride_be,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    # Meta
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    MUL_ROUTED_WEIGHT: tl.constexpr,
+    topk: tl.constexpr,
+    compute_type: tl.constexpr,
+):
+    # 计算位置
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(EM, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(GROUP_SIZE_M, num_pid_m - first_pid_m)
+    pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+    
+    # 划分数据
+    offs = tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
+    num_tokens_post_padded = tl.load(num_tokens_post_pad_ptr)
+    
+    # 如果pid_m对应的token起始位置超过了num_tokens_post_padded, 说明这个block没有有效token, 直接返回
+    if pid_m * BLOCK_SIZE_M >= num_tokens_post_padded:
+        return
+
+    offs_token_id = pid_m * BLOCK_SIZE_M + offs
+    offs_token = tl.load(sorted_token_ids_ptr + offs_token_id)
+    # 将token_id为pad_token_id的token mask掉, 这些token是没有对应专家的, 也就是无效token
+    token_mask = offs_token < num_valid_tokens
+    off_experts = tl.load(expert_ids_ptr + pid_m).to(tl.int64)
+    offs_bn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)
+    offs_k = tl.arange(0, BLOCK_SIZE_K).to(tl.int64)
+    a_ptrs = a_ptr + (
+        offs_token[:, None] // topk * stride_am + offs_k[None, :] * stride_ak
+    )
+    # b.shape(E, K, N)
+    b_ptrs = b_ptr + (
+        off_experts * stride_be + 
+        (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+    )
+    
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(
+            a_ptrs, 
+            mask=token_mask[:, None] & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
+            other=0.0,
+        )
+        b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator += tl.dot(a, b)
+        a_ptrs += BLOCK_SIZE_K * stride_ak
+        b_ptrs += BLOCK_SIZE_K * stride_bk
+        
+    if MUL_ROUTED_WEIGHT:
+        moe_weight = tl.load(
+            topk_weights_ptr + offs_token, 
+            mask=token_mask,
+            other=0,
+        )
+        accumulator = accumulator * moe_weight[:, None]
+    
+    accumulator = accumulator.to(compute_type)
+    # C.shape(topk, M, N)
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)
+    c_ptrs = c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
+    tl.store(c_ptrs, accumulator, mask=token_mask[:, None] & (offs_cn[None, :] < N))
+
+
+def invoke_fused_moe_triton_kernel(
+    A: torch.Tensor,                        # (M, K)
+    B: torch.Tensor,                        # (E, K, N)
+    C: torch.Tensor,                        # (topk * M, N)
+    topk_weights: torch.Tensor | None,      # (M, topk)
+    sorted_token_ids: torch.Tensor | None,
+    expert_ids: torch.Tensor | None,
+    num_tokens_post_pad: torch.Tensor,
+    mul_routed_weight: bool,
+    topk: int,
+    block_size: int,
+):
+    assert topk_weights is not None or not mul_routed_weight, "topk_weights must be provided if mul_routed_weight is True"
+    if sorted_token_ids is None or expert_ids is None:
+        raise ValueError("sorted_token_ids and expert_ids must be provided")
+
+    M, K = A.size(0), A.size(1)
+    num_slots = M * topk
+    BLOCK_SIZE_M = block_size
+    BLOCK_SIZE_N = 32
+    BLOCK_SIZE_K = 16
+    EM = sorted_token_ids.size(0)
+
+    if A.dtype == torch.bfloat16:
+        compute_type = tl.bfloat16
+    elif A.dtype == torch.float16:
+        compute_type = tl.float16
+    elif A.dtype == torch.float32:
+        compute_type = tl.float32
+    else:
+        raise ValueError(f"Unsupported compute_type: {A.dtype}")
+
+    grid = lambda META: (
+        triton.cdiv(EM, BLOCK_SIZE_M) * triton.cdiv(B.size(2), BLOCK_SIZE_N),
+    )
+    fused_moe_triton_kernel[grid](
+        a_ptr=A,
+        b_ptr=B,
+        c_ptr=C,
+        topk_weights_ptr=topk_weights,
+        sorted_token_ids_ptr=sorted_token_ids,
+        expert_ids_ptr=expert_ids,
+        num_tokens_post_pad_ptr=num_tokens_post_pad,
+        N=B.size(2),
+        K=K,
+        EM=EM,
+        num_valid_tokens=num_slots,
+        stride_am=A.stride(0),
+        stride_ak=A.stride(1),
+        stride_be=B.stride(0),
+        stride_bk=B.stride(1),
+        stride_bn=B.stride(2),
+        stride_cm=C.stride(0),
+        stride_cn=C.stride(1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=4,
+        MUL_ROUTED_WEIGHT=mul_routed_weight,
+        topk=topk,
+        compute_type=compute_type,
+    )
+
+
+
+def moe_align_block_size(
+    topk_ids: torch.Tensor,
+    block_size: int,
+    num_experts: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+        参数：
+            topk_ids: (num_tokens, top_k)
+            block_size: int, triton内核的block size, 决定每次用HBM -> SRAM取出的数据个数
+            num_experts: int
+        Example:
+            topk_ids = [[2, 3, 4], [1, 2, 4], [1, 3, 4], [1, 2, 3]]
+            block_size = 4 并且 num_experts = 4:
+            1. 将topk_ids展平为[2, 3, 4, 1, 2, 4, 1, 3, 4, 1, 2, 3], 一共12个数
+            2. 按照专家编号排序得到[3, 6, 9, 0, 4, 10, 1, 7, 11, 2, 5, 8] -> [expert1, expert2, expert3, expert4]
+            3. 对每个专家的token数量进行padding(12), 使得每个专家的token数量都是block_size的整数倍 -> [4, 4, 4, 4]
+            4. 得到排序后的token_id和对应的专家id:
+                [3, 6, 9, 12, 0, 4, 10, 12, 1, 7, 11, 12, 2, 5, 8, 12]
+    """
+    # 最坏情况下会有多少token-expert对(进行padding后)
+    max_num_tokens_padded = topk_ids.numel() + num_experts * (block_size - 1)
+    max_num_tokens_padded = round_up(max_num_tokens_padded, block_size)
+    sorted_ids = torch.empty(
+        (max_num_tokens_padded,), dtype=torch.int32, device=topk_ids.device
+    )
+    max_num_m_blocks = triton.cdiv(max_num_tokens_padded, block_size)
+    expert_ids = torch.empty(
+        (max_num_m_blocks,), dtype=torch.int32, device=topk_ids.device
+    )
+    # 这个变量用来记录padding后的token-expert数量
+    num_tokens_post_pad = torch.empty(
+        (1,), dtype=torch.int32, device=topk_ids.device
+    )
+    num_token_slots = topk_ids.numel()
+    pad_token_id = num_token_slots
+    flatten_topk_ids = topk_ids.flatten()
+    sorted_token_list: list[int] = []
+    block_expert_list: list[int] = []
+    for expert_id in range(num_experts):
+        slot_indices = (flatten_topk_ids == expert_id).nonzero(as_tuple=False).flatten()
+        slot_list = slot_indices.tolist()
+        real_count = len(slot_list)
+        padded_count = round_up(real_count, block_size) if real_count > 0 else 0
+        pad_count = padded_count - real_count
+        if pad_count > 0:
+            slot_list.extend([pad_token_id] * pad_count)
+        sorted_token_list.extend(slot_list)
+        num_blocks_for_this_expert = padded_count // block_size
+        block_expert_list.extend([expert_id] * num_blocks_for_this_expert)
+    
+    # 得到sort_ids
+    num_tokens_post_pad[0] = len(sorted_token_list)
+    if num_tokens_post_pad[0] > 0:
+        sorted_ids[:num_tokens_post_pad[0]] = torch.tensor(
+            sorted_token_list, dtype=torch.int32, device=topk_ids.device
+        )
+    if num_tokens_post_pad[0] < max_num_tokens_padded:
+        sorted_ids[num_tokens_post_pad[0]:] = pad_token_id
+    
+    # 得到expert_ids
+    actual_num_blocks = len(block_expert_list)
+    if actual_num_blocks > 0:
+        expert_ids[:actual_num_blocks] = torch.tensor(
+            block_expert_list, dtype=torch.int32, device=topk_ids.device
+        )
+    if actual_num_blocks < max_num_m_blocks:
+        expert_ids[actual_num_blocks:] = -1
+        
+    return sorted_ids, expert_ids, num_tokens_post_pad
+
+
+
+
+class TritonExperts(mk.FusedMoEPermuteExpertsUnpermute):
+    def __init__(
+        self,
+    ):
+        self.BLOCK_SIZE = 64
+        self.act_fn = SiluAndMul()
+
+    def apply(
+        self,
+        output: torch.Tensor,           
+        hidden_states: torch.Tensor,    
+        w1: torch.Tensor,               
+        w2: torch.Tensor,               
+        topk_weights: torch.Tensor,     
+        topk_ids: torch.Tensor,         
+        activation: str,
+        global_num_experts: int,
+    ):
+        """
+            output: 输出结果, shape(num_tokens, hidden_size)
+            hidden_states: shape(num_tokens, hidden_size)
+            w1: shape(num_experts, hidden_size, 2 * intermediate_size)
+            w2: shape(num_experts, intermediate_size, hidden_size)
+            topk_weights: shape(num_tokens, top_k)
+            topk_ids: shape(num_tokens, top_k)
+        """
+        assert hidden_states.is_contiguous(), "Hidden_states must be contiguous"
+        assert hidden_states.dim() == 2
+        assert topk_weights.is_contiguous(), "topk_weights must be contiguous"
+        assert w1.stride(-1) == 1, "Stride of last dimension must be 1"
+        assert w2.stride(-1) == 1, "Stride of last dimension must be 1"
+
+        num_experts, num_tokens, intermediate_size, hidden_size, top_k_num = self.moe_problem_size(
+            hidden_states, w1, w2, topk_ids
+        )
+        
+        assert topk_weights.shape == topk_ids.shape
+        assert num_experts == global_num_experts
+        assert w1.size(2) == 2 * intermediate_size
+        assert w2.size(2) == hidden_size
+        if activation != "silu":
+            raise ValueError(f"Unsupported activation: {activation}")
+        
+        # 按照expert 重排 token
+        sorted_token_ids, expert_ids, num_tokens_post_pad = moe_align_block_size(
+            topk_ids=topk_ids,
+            block_size=self.BLOCK_SIZE,  
+            num_experts=global_num_experts,
+        )
+        
+        # 第一层expert matual: xw1
+        gate_up = torch.empty(
+            (num_tokens * top_k_num, 2 * intermediate_size),
+            device=hidden_states.device,
+            dtype=hidden_states.dtype,
+        )
+        
+        # C = A @ B --> (M, K) @ (E, K, N) -> (M * topk, N)
+        invoke_fused_moe_triton_kernel(
+            A=hidden_states,
+            B=w1,
+            C=gate_up,
+            topk_weights=None,
+            sorted_token_ids=sorted_token_ids,
+            expert_ids=expert_ids,
+            num_tokens_post_pad=num_tokens_post_pad,
+            mul_routed_weight=False,
+            topk=top_k_num,
+            block_size=self.BLOCK_SIZE,
+        )
+        
+        # 激活函数
+        activated = self.act_fn(gate_up)
+        
+        # 第二层expert matmul: xw2
+        expert_out = torch.empty(
+            (num_tokens * top_k_num, hidden_size),
+            device=hidden_states.device,
+            dtype=hidden_states.dtype,
+        )
+    
+        # C = A @ B --> (M * topk, N) @ (E, N, K) -> (M * topk, K)
+        invoke_fused_moe_triton_kernel(
+            A=activated,
+            B=w2,
+            C=expert_out,
+            topk_weights=topk_weights,
+            sorted_token_ids=sorted_token_ids,
+            expert_ids=expert_ids,
+            num_tokens_post_pad=num_tokens_post_pad,
+            mul_routed_weight=True,
+            topk=1,
+            block_size=self.BLOCK_SIZE,
+        )
+        
+        
+        output.copy_(
+            expert_out.view(num_tokens, top_k_num, hidden_size).sum(dim=1)
+        )
+        return output

--- a/nanovllm/layers/fused_moe/layer.py
+++ b/nanovllm/layers/fused_moe/layer.py
@@ -1,0 +1,102 @@
+import torch
+import torch.nn as nn
+from nanovllm.layers.linear import MergedColumnParallelLinear, RowParallelLinear
+from nanovllm.layers.fused_moe.router.fused_topk_router import (FusedTopKRouter)
+from nanovllm.layers.fused_moe.unquantized_fused_moe_method import (
+    UnquantizedFusedMoEMethod,
+)
+
+class _ExpertMLP(nn.Module):
+    # 复用 linear.py 中已有的并行线性层和 weight_loader 逻辑。
+    def __init__(self, hidden_size: int, intermediate_size: int):
+        super().__init__()
+        self.gate_up_proj = MergedColumnParallelLinear(
+            hidden_size,
+            [intermediate_size] * 2,
+            bias=False,
+        )
+        self.down_proj = RowParallelLinear(
+            intermediate_size,
+            hidden_size,
+            bias=False,
+        )
+
+
+class FusedMoE(nn.Module):
+    def __init__(
+        self,
+        num_experts: int,
+        top_k: int,
+        hidden_size: int,
+        intermediate_size: int,
+        tp_size: int | None = None,
+        activation: str = "silu",
+    ):
+        super().__init__()
+        self.num_experts = num_experts
+        self.global_num_experts = num_experts
+        self.local_num_experts = num_experts
+        self.top_k = top_k
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.tp_size = tp_size
+        self.activation = activation
+        for expert_id in range(num_experts):
+            self.add_module(str(expert_id), _ExpertMLP(hidden_size, intermediate_size))
+        self.quant_method = UnquantizedFusedMoEMethod(
+            num_experts=num_experts,
+            experts_per_token=top_k,
+            hidden_dim=hidden_size,
+            intermediate_size_per_partition=intermediate_size,
+            num_local_experts=num_experts,
+            activation=activation,
+        )
+        self.router = FusedTopKRouter(
+            top_k=top_k,
+            global_num_experts=self.global_num_experts,
+            scoring_func="softmax",
+        )
+
+    def _get_expert(self, expert_id: int) -> _ExpertMLP:
+        return getattr(self, str(expert_id))
+
+    @property
+    def w13_weight(self) -> torch.Tensor:
+        """
+            w13是所有专家门控FFN的gate, up权重矩阵的合并版本, shape(num_experts, hidden_size, 2 * intermediate_size)
+        """
+        experts = []
+        for expert_id in range(self.num_experts):
+            expert = self._get_expert(expert_id)
+            experts.append(expert.gate_up_proj.weight.transpose(0, 1))
+        return torch.stack(experts, dim=0).contiguous()
+
+    @property
+    def w2_weight(self) -> torch.Tensor:
+        """
+            w2是所有专家门控FFN的down权重矩阵的合并版本, shape(num_experts, intermediate_size, hidden_size)
+        """
+        experts = []
+        for expert_id in range(self.num_experts):
+            expert = self._get_expert(expert_id)
+            experts.append(expert.down_proj.weight.transpose(0, 1))
+        return torch.stack(experts, dim=0).contiguous()
+        
+        
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor
+    ) -> torch.Tensor:
+        topk_weights, topk_ids = self.router.select_experts(
+            hidden_states=hidden_states,
+            router_logits=router_logits,
+        )
+        
+        final_hidden_states = self.quant_method.apply(
+            layer=self,
+            x=hidden_states,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+        )
+        return final_hidden_states

--- a/nanovllm/layers/fused_moe/modular_kernel.py
+++ b/nanovllm/layers/fused_moe/modular_kernel.py
@@ -1,0 +1,130 @@
+import torch
+from abc import ABC, abstractmethod
+
+"""
+    moe模型为了进行高效的推理优化, 一般划分为：
+    1. Prepare
+    2. permute & unpermute
+    3. Finalize
+
+"""
+
+class FusedMoEPrepareAndFinalize(ABC):
+    @abstractmethod
+    def prepare(
+        self,
+        a1: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        num_experts: int,
+    ):
+        raise NotImplementedError
+
+    @abstractmethod
+    def finalize(
+        self,
+        output: torch.Tensor,
+        fused_expert_output: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> None:
+        raise NotImplementedError
+
+
+class FusedMoEPermuteExpertsUnpermute(ABC):
+    def __init__(
+        self,
+        max_num_tokens: int | None = None,
+    ):
+        self.max_num_tokens = max_num_tokens
+
+    def moe_problem_size(
+        self,
+        a1: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> tuple[int, int, int, int, int]:
+        """
+            E: 专家个数
+            M: token数
+            K: hidden size
+            N: intermediate size, 这里就是w2.size(1)
+            topk: 每个token路由的专家数
+            使用这些符号是因为算子的Gemm中(M, K) @ (K, N) -> (M, N)
+        """
+        assert w1.dim() == 3 and w2.dim() == 3
+        E, K, _ = w1.size()
+        assert a1.dim() == 2
+        assert topk_ids.dim() == 2
+        assert topk_ids.size(0) == a1.size(0), f"{topk_ids.size(0)} != {a1.size(0)}"
+        M = a1.size(0)
+        topk = topk_ids.size(1)
+        return E, M, w2.size(1), K, topk
+
+    @abstractmethod
+    def apply(
+        self,
+        output: torch.Tensor,
+        hidden_states: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        activation: str,
+        global_num_experts: int,
+    ) -> None:
+        raise NotImplementedError
+
+
+class FusedMoEModularKernel(torch.nn.Module):
+    def __init__(
+        self,
+        prepare_finalize: FusedMoEPrepareAndFinalize,
+        fused_experts: FusedMoEPermuteExpertsUnpermute,
+    ):
+        super().__init__()
+        self.prepare_finalize = prepare_finalize
+        self.fused_experts = fused_experts
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        inplace: bool = False,
+        activation: str = "silu",
+        global_num_experts: int = -1,
+    ) -> torch.Tensor:
+        if global_num_experts == -1:
+            global_num_experts = w1.size(0)
+
+        self.prepare_finalize.prepare(
+            hidden_states,
+            topk_weights,
+            topk_ids,
+            global_num_experts,
+        )
+
+        fused_out = torch.empty_like(hidden_states)
+        self.fused_experts.apply(
+            output=fused_out,
+            hidden_states=hidden_states,
+            w1=w1,
+            w2=w2,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            activation=activation,
+            global_num_experts=global_num_experts,
+        )
+
+        output = hidden_states if inplace else torch.empty_like(hidden_states)
+        self.prepare_finalize.finalize(
+            output,
+            fused_out,
+            topk_weights,
+            topk_ids,
+        )
+        return output

--- a/nanovllm/layers/fused_moe/prepare_finalize.py
+++ b/nanovllm/layers/fused_moe/prepare_finalize.py
@@ -1,0 +1,34 @@
+import nanovllm.layers.fused_moe.modular_kernel as mk
+import torch
+
+class MoEPrepareAndFinalizeNoEP(mk.FusedMoEPrepareAndFinalize):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def prepare(
+        self,
+        a1: torch.Tensor,          
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        num_experts: int,
+    ):
+        # vllm的实现中, prepare阶段会对a1进行量化, 以得到a1q和a1q_scale. 
+        # 但是在这个实现中, 我们不进行量化, 所以这个函数什么都不做
+        return
+
+    def finalize(
+        self,
+        output: torch.Tensor,
+        fused_expert_output: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> None:
+        """权重聚合在算子中已经完成，这个函数只需要把结果从fused_expert_output复制到output即可"""
+        if output is None:
+            return fused_expert_output
+        
+        assert output.shape == fused_expert_output.shape, (
+            f"output shape {output.shape} does not match fused_expert_output shape {fused_expert_output.shape}"
+        )
+        output.copy_(fused_expert_output, non_blocking=True)
+        return output

--- a/nanovllm/layers/fused_moe/router/base_router.py
+++ b/nanovllm/layers/fused_moe/router/base_router.py
@@ -1,0 +1,48 @@
+from nanovllm.layers.fused_moe.router.fused_moe_router import FusedMoERouter
+from abc import abstractmethod
+import torch
+
+class BaseRouter(FusedMoERouter):
+    """
+    Base router class that provides common functionality for all router implementations.
+
+    This class implements the template method pattern where select_experts() handles
+    common pre-processing and post-processing, delegating the actual routing logic
+    to the abstract _compute_routing() method.
+    """
+
+    def __init__(
+        self,
+        top_k: int,
+        global_num_experts: int,
+    ):
+        """
+        Note: the indices dtype might not be available at router construction
+        time, so we need to supply a callback to get it at runtime.  This is
+        because the indices type is supplied by modular kernels which are
+        created after MoE layer/router construction.
+        """
+        super().__init__()
+        self.top_k = top_k
+        self.global_num_experts = global_num_experts
+
+
+    @abstractmethod
+    def _compute_routing(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError
+
+
+    def select_experts(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        topk_weights, topk_ids = self._compute_routing(
+            hidden_states, router_logits
+        )
+
+        return topk_weights, topk_ids

--- a/nanovllm/layers/fused_moe/router/fused_moe_router.py
+++ b/nanovllm/layers/fused_moe/router/fused_moe_router.py
@@ -1,0 +1,25 @@
+from abc import ABC, abstractmethod
+import torch
+
+class FusedMoERouter(ABC):
+
+    @abstractmethod
+    def select_experts(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Route the input hidden states to the top-k experts based on the
+        router logits.
+
+        Returns:
+            (topk_weights, topk_ids)
+            (tuple[torch.Tensor, torch.Tensor]):
+            The weights and expert ids computation result.
+
+            **Compatibility**: When EPLB is not enabled, the returned ids are
+            equivalent to global logical ids, so should be compatible with
+            plain MoE implementations without redundant experts.
+        """
+        raise NotImplementedError

--- a/nanovllm/layers/fused_moe/router/fused_topk_router.py
+++ b/nanovllm/layers/fused_moe/router/fused_topk_router.py
@@ -1,0 +1,176 @@
+import torch
+import triton
+import triton.language as tl
+from nanovllm.layers.fused_moe.router.base_router import BaseRouter
+
+@triton.jit
+def topk_softmax_kernel(
+    topk_weights_ptr,
+    topk_ids_ptr,
+    token_expert_indices_ptr,
+    gating_output_ptr,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    TOPK: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    if pid >= M:
+        return
+
+    cols = tl.arange(0, BLOCK_SIZE)
+    mask = cols < N
+
+    row_offsets = pid * N + cols
+    logits = tl.load(
+        gating_output_ptr + row_offsets,
+        mask=mask,
+        other=float("-inf"),
+    ).to(tl.float32)
+
+    # 稳定softmax
+    logits = logits - tl.max(logits, axis=0)
+    probs = tl.exp(logits)
+    probs = probs / tl.sum(probs, axis=0)
+
+    output_base = pid * TOPK
+    for k in tl.static_range(TOPK):
+        top_idx = tl.argmax(probs, axis=0)
+        top_val = tl.max(probs, axis=0)
+
+        tl.store(topk_weights_ptr + output_base + k, top_val)
+        tl.store(topk_ids_ptr + output_base + k, top_idx.to(tl.int32))
+        tl.store(token_expert_indices_ptr + output_base + k, k)
+
+        probs = tl.where(cols == top_idx, float("-inf"), probs)
+
+def invoke_topk_softmax(
+    topk_weights: torch.Tensor,
+    topk_indices: torch.Tensor,
+    token_expert_indices: torch.Tensor,
+    gating_output: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if gating_output.ndim != 2:
+        raise ValueError("gating_output must have shape [num_tokens, num_experts].")
+    if topk_weights.ndim != 2 or topk_indices.ndim != 2:
+        raise ValueError("top-k outputs must be rank-2 tensors.")
+    if token_expert_indices.shape != topk_indices.shape:
+        raise ValueError("token_expert_indices must match topk_indices shape.")
+
+    num_tokens, num_experts = gating_output.shape
+    topk = topk_weights.size(1)
+
+    if topk > num_experts:
+        raise ValueError(
+            f"topk ({topk}) must be <= number of experts ({num_experts})."
+        )
+
+    if topk_weights.shape != (num_tokens, topk):
+        raise ValueError("topk_weights has an incompatible shape.")
+    if topk_indices.shape != (num_tokens, topk):
+        raise ValueError("topk_indices has an incompatible shape.")
+
+    # 使得gating_output在内存中是连续的，以便triton内核高效访问
+    gating_output = gating_output.contiguous()
+
+    if not gating_output.is_cuda:
+        routing_weights = torch.softmax(gating_output, dim=-1, dtype=torch.float32)
+        topk_values, topk_ids = torch.topk(routing_weights, k=topk, dim=-1)
+        topk_weights.copy_(topk_values)
+        topk_indices.copy_(topk_ids.to(torch.int32))
+        token_expert_indices.copy_(
+            torch.arange(topk, device=gating_output.device, dtype=torch.int32)
+            .unsqueeze(0)
+            .expand_as(token_expert_indices)
+        )
+        return topk_weights, topk_indices
+    block_size = triton.next_power_of_2(num_experts)
+    num_warps = 4
+    if block_size >= 2048:
+        num_warps = 8
+    elif block_size <= 256:
+        num_warps = 2
+
+    topk_softmax_kernel[(num_tokens,)](
+        topk_weights,
+        topk_indices,
+        token_expert_indices,
+        gating_output,
+        M=num_tokens,
+        N=num_experts,
+        TOPK=topk,
+        BLOCK_SIZE=block_size,
+        num_warps=num_warps,
+    )
+
+    return topk_weights, topk_indices
+
+
+def fused_topk(
+    hidden_states: torch.Tensor,
+    gating_output: torch.Tensor,
+    topk: int,
+    renormalize: bool = True,
+    scoring_func: str = "softmax",
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    assert hidden_states.size(0) == gating_output.size(0), "Number of tokens mismatch"
+
+    M, _ = hidden_states.size()
+
+    topk_weights = torch.empty(
+        M, topk, dtype=torch.float32, device=hidden_states.device
+    )
+    topk_ids = torch.empty(
+        M,
+        topk,
+        dtype=torch.int32,
+        device=hidden_states.device,
+    )
+    token_expert_indices = torch.empty(
+        M, topk, dtype=torch.int32, device=hidden_states.device
+    )
+
+    if scoring_func == "softmax":
+        topk_weights, topk_ids = invoke_topk_softmax(
+            topk_weights, topk_ids, token_expert_indices, gating_output
+        )
+        if renormalize:
+            topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+
+        return topk_weights, topk_ids, token_expert_indices
+    else:
+        raise ValueError(f"Unsupported scoring function: {scoring_func}")
+
+
+class FusedTopKRouter(BaseRouter):
+    """Default router using standard fused top-k routing."""
+    def __init__(
+        self,
+        top_k: int,
+        global_num_experts: int,
+        scoring_func: str = "softmax",
+        renormalize: bool = True,
+    ):
+        super().__init__(
+            top_k=top_k,
+            global_num_experts=global_num_experts,
+        )
+        self.renormalize = renormalize
+        self.scoring_func = scoring_func
+
+
+    def _compute_routing(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Compute routing using standard fused top-k."""
+        topk_weights, topk_ids, token_expert_indices = fused_topk(
+            hidden_states=hidden_states,
+            gating_output=router_logits,
+            topk=self.top_k,
+            renormalize=self.renormalize,
+            scoring_func=self.scoring_func,
+        )
+
+        return topk_weights, topk_ids

--- a/nanovllm/layers/fused_moe/shared_fused_moe.py
+++ b/nanovllm/layers/fused_moe/shared_fused_moe.py
@@ -1,0 +1,12 @@
+from nanovllm.layers.fused_moe.layer import FusedMoE
+import torch
+class SharedFusedMoE(FusedMoE):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor
+    ) -> torch.Tensor:
+        return super().forward(hidden_states, router_logits)

--- a/nanovllm/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/nanovllm/layers/fused_moe/unquantized_fused_moe_method.py
@@ -1,0 +1,54 @@
+import torch
+import torch.nn as nn
+import nanovllm.layers.fused_moe.modular_kernel as mk
+from nanovllm.layers.fused_moe.fused_moe import TritonExperts
+from nanovllm.layers.fused_moe.prepare_finalize import MoEPrepareAndFinalizeNoEP
+
+
+class UnquantizedFusedMoEMethod(nn.Module):
+    def __init__(
+        self,
+        num_experts: int,
+        experts_per_token: int,
+        hidden_dim: int,
+        intermediate_size_per_partition: int,
+        num_local_experts: int,
+        activation: str = "silu",
+    ):
+       super().__init__()
+       self.kernel = mk.FusedMoEModularKernel(
+           prepare_finalize=MoEPrepareAndFinalizeNoEP(),
+           fused_experts=TritonExperts(),
+       )
+       
+    def apply(
+        self,
+        layer: nn.Module,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        return self.forward(
+            layer=layer,
+            x=x,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+        )
+    
+    def forward(
+        self,
+        layer: nn.Module,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ):
+        return self.kernel(
+            hidden_states=x,
+            w1=layer.w13_weight,
+            w2=layer.w2_weight,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            activation=layer.activation,
+            global_num_experts=layer.global_num_experts,
+        )
+    

--- a/nanovllm/layers/rotary_embedding.py
+++ b/nanovllm/layers/rotary_embedding.py
@@ -54,6 +54,8 @@ def get_rope(
     rotary_dim: int,
     max_position: int,
     base: float,
+    rope_scaling: dict | None = None,
 ):
+    assert rope_scaling is None
     rotary_emb = RotaryEmbedding(head_size, rotary_dim, max_position, base)
     return rotary_emb

--- a/nanovllm/models/qwen3_moe.py
+++ b/nanovllm/models/qwen3_moe.py
@@ -1,0 +1,311 @@
+import torch
+from torch import nn
+import torch.distributed as dist
+from transformers import Qwen3MoeConfig
+from torch.nn import functional as F
+from nanovllm.layers.activation import SiluAndMul
+from nanovllm.layers.attention import Attention
+from nanovllm.layers.layernorm import RMSNorm
+from nanovllm.layers.linear import QKVParallelLinear, MergedColumnParallelLinear, RowParallelLinear, ReplicatedLinear
+from nanovllm.layers.rotary_embedding import get_rope
+from nanovllm.layers.embed_head import VocabParallelEmbedding, ParallelLMHead
+from nanovllm.layers.fused_moe.shared_fused_moe import SharedFusedMoE
+
+class Qwen3MoeMLP(nn.Module):
+    def __init__(
+            self,
+            hidden_size: int,
+            intermediate_size: int,
+            hidden_act: str,
+    ) -> None:
+        super().__init__()
+        self.gate_up_proj = MergedColumnParallelLinear(
+            hidden_size,    # input_size
+            [intermediate_size] * 2,
+            bias=False,
+        )
+        self.down_proj = RowParallelLinear(
+            intermediate_size,
+            hidden_size,
+            bias=False,
+        )
+        assert hidden_act == "silu"
+        self.act_fn = SiluAndMul()
+
+
+    def forward(self, x):
+        gate_up = self.gate_up_proj(x)
+        x = self.act_fn(gate_up)
+        x = self.down_proj(x)
+        return x
+
+
+class Qwen3MoeSparseMoeBlockOld(nn.Module):
+    def __init__(
+            self,
+            config:  Qwen3MoeConfig,
+    ) -> None:
+        super().__init__()
+        self.n_routed_experts = config.num_experts
+        self.top_k = config.num_experts_per_tok
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.moe_intermediate_size
+        # 最简化的方式(测试)
+        self.experts = nn.ModuleList(
+            [Qwen3MoeMLP(config.hidden_size, config.moe_intermediate_size, config.hidden_act) for _ in range(self.n_routed_experts)]
+        )
+        self.gate = ReplicatedLinear(
+            config.hidden_size,
+            self.n_routed_experts,
+        )
+
+    def forward(self, hidden_states) -> torch.Tensor:
+        # 形状: [batch*seq, hidden_size]
+        batch_seq, hidden = hidden_states.shape
+        router_logits = self.gate(hidden_states)  # [batch_seq, num_experts]
+
+        # Softmax + top-k 选择（核心路由）
+        routing_weights = F.softmax(router_logits, dim=-1)  # [batch_seq, num_experts]
+        routing_weights, selected_experts = torch.topk(routing_weights, self.top_k,
+                                                       dim=-1)  # weights [batch_seq, top_k], experts [batch_seq, top_k]
+        routing_weights = routing_weights / routing_weights.sum(dim=-1, keepdim=True)  # 归一化
+
+        # 初始化输出
+        final_hidden_states = torch.zeros_like(hidden_states)
+
+        # 逐 token 计算（简化循环；实际用 scatter/gather 优化）
+        for expert_idx in range(self.n_routed_experts):
+            mask = (selected_experts == expert_idx).any(dim=-1)  # [batch_seq]
+            if mask.sum() == 0:
+                continue  # 跳过未选专家
+            local_hidden = hidden_states[mask]  # 选中的 token
+            expert_out = self.experts[expert_idx](local_hidden)  # 计算
+            # 加权回原位置（简化）
+            per_token_expert_mask = (selected_experts[mask] == expert_idx)  # [num_masked, top_k] bool
+            per_token_weights = (routing_weights[mask] * per_token_expert_mask.float()).sum(dim=-1)  # [num_masked]
+            final_hidden_states[mask] += per_token_weights.unsqueeze(-1) * expert_out
+
+        return final_hidden_states
+
+class Qwen3MoeSparseMoeBlock(nn.Module):
+    def __init__(
+            self,
+            config:  Qwen3MoeConfig,
+    ) -> None:
+        super().__init__()
+        self.n_routed_experts = config.num_experts
+        self.top_k = config.num_experts_per_tok
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.moe_intermediate_size
+        self.gate = ReplicatedLinear(
+            config.hidden_size,
+            self.n_routed_experts,
+        )
+        
+        self.experts = SharedFusedMoE(
+            num_experts=self.n_routed_experts,
+            top_k=self.top_k,
+            hidden_size=config.hidden_size,
+            intermediate_size=config.moe_intermediate_size,
+        )
+        
+
+    def forward(self, hidden_states) -> torch.Tensor:
+        assert hidden_states.dim() == 2, (
+            "Qwen3MoeSparseMoeBlock expects input hidden_states to have shape [batch*seq, hidden_size]"
+        )
+        num_tokens, hidden_dim = hidden_states.shape
+        router_logits = self.gate(hidden_states)    # [num_tokens, num_experts]
+        fused_out = self.experts(hidden_states, router_logits)  # [num_tokens, hidden_size]
+        return fused_out
+    
+class Qwen3MoeAttention(nn.Module):
+    def __init__(
+            self,
+            hidden_size: int,               # embedding后的词维度
+            num_heads: int,
+            num_kv_heads: int,
+            max_position: int = 4096 * 32,
+            head_dim: int | None = None,    # 每个注意力头的维度(hidden_size / num_head)：通过线性变换降维，而非简单截取输入矩阵X
+            rms_norm_eps: float = 1e-06,
+            qkv_bias: bool = False,
+            rope_theta: float = 10000,
+            rope_scaling: tuple | None = None,
+    ) -> None:
+        super().__init__()
+        tp_size = dist.get_world_size()
+        self.hidden_size = hidden_size
+        self.total_num_heads = num_heads
+        assert self.total_num_heads % tp_size == 0
+        self.num_heads = self.total_num_heads // tp_size
+        self.total_num_kv_heads = num_kv_heads
+        
+        # assert self.total_num_kv_heads % tp_size == 0
+        if self.total_num_kv_heads >= tp_size:
+            assert self.total_num_kv_heads % tp_size == 0
+        else:
+            assert tp_size % self.total_num_kv_heads == 0
+
+        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+        self.head_dim = head_dim or hidden_size // self.total_num_heads
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.scaling = self.head_dim ** -0.5
+        self.qkv_bias = qkv_bias
+        self.rope_theta = rope_theta
+        self.qkv_proj = QKVParallelLinear(
+            hidden_size,
+            self.head_dim,
+            self.total_num_heads,
+            self.total_num_kv_heads,
+            bias=qkv_bias,
+        )
+        self.o_proj = RowParallelLinear(
+            self.total_num_heads * self.head_dim,
+            hidden_size,
+            bias = False
+        )
+        self.rotary_emb = get_rope(
+            self.head_dim,
+            rotary_dim=self.head_dim,
+            max_position=max_position,
+            base=rope_theta,
+            rope_scaling=rope_scaling,
+        )
+        self.attn = Attention(
+            self.num_heads,
+            self.head_dim,
+            self.scaling,
+            self.num_kv_heads,
+        )
+        if not self.qkv_bias:
+            self.q_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
+            self.k_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
+    def forward(
+            self,
+            positions: torch.Tensor,
+            hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        打印Attention的forward的维度变换————decoder阶段
+        hidden_states： torch.Size([1, 1024])   # 当batch_size = 1且seq_len = 1时，维度会变为(b * s, hidden_size)，推理过程(decode)，seq_len为1，而在prefill时，seq_len不为1
+        qkv： torch.Size([1, 4096])             # (batch_size, seq_len, q_size + k_size + v_size)
+        q.shape： torch.Size([1, 16, 128])      # (batch_size * seq_len, num_heads, head_dim)
+        k.shape torch.Size([1, 8, 128])         # (batch_size * seq_len, num_kv_heads, head_dim)
+        v.shape： torch.Size([1, 8, 128])       # (batch_size * seq_len, num_kv_heads, head_dim)
+        o.shape： torch.Size([1, 1, 16, 128])   # (batch_size, seq_len, num_heads, head_dim)
+        output.shape： torch.Size([1, 1024])    # (batch_size, seq_len * num_heads * head_dim)
+        """
+        qkv = self.qkv_proj(hidden_states)
+        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        q = q.view(-1, self.num_heads, self.head_dim)
+        k = k.view(-1, self.num_kv_heads, self.head_dim)
+        v = v.view(-1, self.num_kv_heads, self.head_dim)
+        if not self.qkv_bias:
+            q = self.q_norm(q)
+            k = self.k_norm(k)
+        q, k = self.rotary_emb(positions, q, k)
+        o = self.attn(q, k, v)
+        output = self.o_proj(o.flatten(1, -1))
+        return output
+
+class Qwen3MoeDecoderLayer(nn.Module):
+    def __init__(
+            self,
+            config:  Qwen3MoeConfig,
+            mlp_kind: int = 0
+    ) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.self_attn = Qwen3MoeAttention(
+            hidden_size=config.hidden_size,
+            num_heads=config.num_attention_heads,
+            num_kv_heads=config.num_key_value_heads,
+            max_position=config.max_position_embeddings,
+            rms_norm_eps=config.rms_norm_eps,
+            qkv_bias=getattr(config, 'attention_bias', True),
+            head_dim=getattr(config, 'head_dim', None),
+            rope_theta=getattr(config, "rope_theta", 1000000),
+            rope_scaling=getattr(config, "rope_scaling", None),
+        )
+
+        if mlp_kind == 0:
+            self.mlp = Qwen3MoeSparseMoeBlock(config=config)
+        else:
+            self.mlp = Qwen3MoeMLP(config.hidden_size, config.moe_intermediate_size, config.hidden_act)
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+    def forward(
+            self,
+            positions: torch.Tensor,
+            hidden_states: torch.Tensor,
+            residual: torch.Tensor | None,      # 残差
+    ):
+        if residual is None:
+            hidden_states, residual = self.input_layernorm(hidden_states), hidden_states
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+        hidden_states = self.self_attn(positions, hidden_states)
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states = self.mlp(hidden_states)
+        return hidden_states, residual
+
+class Qwen3MoeModel(nn.Module):
+    def __init__(
+            self,
+            config: Qwen3MoeConfig,
+    ) -> None:
+        super().__init__()
+        self.embed_tokens = VocabParallelEmbedding(config.vocab_size, config.hidden_size)
+        # self.layers = nn.ModuleList([ Qwen3MoeDecoderLayer(config) for _ in range(config.num_hidden_layers)])
+        self.layers = nn.ModuleList()
+        for layer_id in range(config.num_hidden_layers):
+            if config.mlp_only_layers and layer_id in config.mlp_only_layers:
+                self.layers.append(Qwen3MoeDecoderLayer(config, 1))
+            else:
+                if (layer_id + 1) % config.decoder_sparse_step == 0:
+                    self.layers.append(Qwen3MoeDecoderLayer(config, 0))
+                else:
+                    self.layers.append(Qwen3MoeDecoderLayer(config, 1))
+        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+    def forward(
+            self,
+            input_ids: torch.Tensor,
+            positions: torch.Tensor,
+    ) -> torch.Tensor:
+        hidden_states = self.embed_tokens(input_ids)
+        residual = None
+        for layer in self.layers:
+            hidden_states, residual = layer(positions, hidden_states, residual)
+        hidden_states, _ = self.norm(hidden_states, residual)
+        return hidden_states
+
+class Qwen3MoeForCausalLM(nn.Module):
+    packed_modules_mapping = {
+        "q_proj": ("qkv_proj", "q"),
+        "k_proj": ("qkv_proj", "k"),
+        "v_proj": ("qkv_proj", "v"),
+        "gate_proj": ("gate_up_proj", 0),
+        "up_proj": ("gate_up_proj", 1),
+    }
+    def __init__(
+            self,
+            config:  Qwen3MoeConfig,
+    ) -> None:
+        super().__init__()
+        self.model = Qwen3MoeModel(config)
+        self.lm_head = ParallelLMHead(config.vocab_size, config.hidden_size)
+        if config.tie_word_embeddings:
+            self.lm_head.weight.data = self.model.embed_tokens.weight.data
+    def forward(
+            self,
+            input_ids: torch.Tensor,
+            positions: torch.Tensor,
+    ) -> torch.Tensor:
+       return self.model(input_ids, positions)
+
+    def compute_logits(
+            self,
+            hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        return self.lm_head(hidden_states)

--- a/nanovllm/models/qwen3_moe.py
+++ b/nanovllm/models/qwen3_moe.py
@@ -165,12 +165,13 @@ class Qwen3MoeAttention(nn.Module):
             hidden_size,
             bias = False
         )
+        if isinstance(rope_scaling, dict):
+            rope_theta = rope_scaling.get("rope_theta", rope_theta)
         self.rotary_emb = get_rope(
             self.head_dim,
             rotary_dim=self.head_dim,
             max_position=max_position,
             base=rope_theta,
-            rope_scaling=rope_scaling,
         )
         self.attn = Attention(
             self.num_heads,

--- a/nanovllm/models/registry.py
+++ b/nanovllm/models/registry.py
@@ -1,0 +1,4 @@
+NANO_VLLM_MODELS = {
+    "Qwen3ForCausalLM": ("qwen3", "Qwen3ForCausalLM"),
+    "Qwen3MoeForCausalLM": ("qwen3_moe", "Qwen3MoeForCausalLM")
+}

--- a/nanovllm/utils/loader.py
+++ b/nanovllm/utils/loader.py
@@ -1,8 +1,19 @@
 import os
 from glob import glob
 import torch
+import importlib
 from torch import nn
 from safetensors import safe_open
+from nanovllm.models.registry import NANO_VLLM_MODELS
+
+def load_model_arch_from_config(hf_config):
+    arch = hf_config.architectures[0]
+    if arch not in NANO_VLLM_MODELS:
+        raise ValueError(f"Unsupported architecture: {arch}")
+    module_name, class_name = NANO_VLLM_MODELS[arch]
+    module = importlib.import_module(f"nanovllm.models.{module_name}")
+    model_cls = getattr(module, class_name)
+    return model_cls
 
 
 def default_weight_loader(param: nn.Parameter, loaded_weight: torch.Tensor):

--- a/nanovllm/utils/math_utils.py
+++ b/nanovllm/utils/math_utils.py
@@ -1,0 +1,4 @@
+
+def round_up(x: int, y: int) -> int:
+    """Round up x to the nearest multiple of y."""
+    return ((x + y - 1) // y) * y


### PR DESCRIPTION
Port complete MoE functionality: Qwen3MoeForCausalLM model, fused_moe triton kernels, top-k router, and modular kernel architecture. Model loading now routes via registry based on hf_config.architectures, so both Qwen3 and Qwen3-MoE are supported.