### PR TITLE
Reuse NumPy-packed decode inputs for CUDA Graph replay

### DIFF
--- a/nanovllm/engine/decode_input_batch.py
+++ b/nanovllm/engine/decode_input_batch.py
@@ -1,0 +1,125 @@
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+
+from nanovllm.engine.sequence import Sequence
+
+
+@dataclass(frozen=True, slots=True)
+class DecodeBatchView:
+    batch_size: int
+    graph_bucket: int
+    active_block_width: int
+    padding_rows: int
+
+
+class DecodeInputBatch:
+    """Persistent CPU staging buffers for CUDA graph decode metadata."""
+
+    def __init__(
+        self,
+        max_batch_size: int,
+        max_num_blocks: int,
+        block_size: int,
+        *,
+        pin_memory: bool = True,
+        allocate_temperature_gpu: bool = True,
+        device: torch.device | str = "cuda",
+    ):
+        if max_batch_size < 1:
+            raise ValueError("max_batch_size must be positive")
+        if max_num_blocks < 1:
+            raise ValueError("max_num_blocks must be positive")
+        if block_size < 1:
+            raise ValueError("block_size must be positive")
+
+        self.max_batch_size = max_batch_size
+        self.max_num_blocks = max_num_blocks
+        self.block_size = block_size
+        factory = {"device": "cpu", "pin_memory": pin_memory}
+        self.input_ids_cpu = torch.empty(max_batch_size, dtype=torch.int64, **factory)
+        self.positions_cpu = torch.empty(max_batch_size, dtype=torch.int64, **factory)
+        self.slot_mapping_cpu = torch.empty(max_batch_size, dtype=torch.int32, **factory)
+        self.context_lens_cpu = torch.empty(max_batch_size, dtype=torch.int32, **factory)
+        self.block_tables_cpu = torch.empty(
+            max_batch_size, max_num_blocks, dtype=torch.int32, **factory
+        )
+        self.temperatures_cpu = torch.empty(max_batch_size, dtype=torch.float32, **factory)
+        self.temperatures_gpu = (
+            torch.empty(max_batch_size, dtype=torch.float32, device=device)
+            if allocate_temperature_gpu
+            else None
+        )
+
+        # NumPy views share the pinned tensor storage and make bulk CPU writes cheap.
+        self.input_ids_np = self.input_ids_cpu.numpy()
+        self.positions_np = self.positions_cpu.numpy()
+        self.slot_mapping_np = self.slot_mapping_cpu.numpy()
+        self.context_lens_np = self.context_lens_cpu.numpy()
+        self.block_tables_np = self.block_tables_cpu.numpy()
+        self.temperatures_np = self.temperatures_cpu.numpy()
+        self.last_view: DecodeBatchView | None = None
+
+    def prepare_decode(
+        self,
+        seqs: list[Sequence],
+        graph_bucket: int,
+        include_temperatures: bool,
+    ) -> DecodeBatchView:
+        batch_size = len(seqs)
+        if batch_size < 1:
+            raise ValueError("decode batch cannot be empty")
+        if batch_size > graph_bucket or graph_bucket > self.max_batch_size:
+            raise ValueError(
+                f"invalid graph bucket {graph_bucket} for batch size {batch_size} "
+                f"and capacity {self.max_batch_size}"
+            )
+
+        active_block_width = max(len(seq.block_table) for seq in seqs)
+        if active_block_width < 1:
+            raise ValueError("decode sequences must own at least one KV-cache block")
+        if active_block_width > self.max_num_blocks:
+            raise ValueError(
+                f"block-table width {active_block_width} exceeds capacity {self.max_num_blocks}"
+            )
+
+        # Initialize the entire captured bucket so padded graph lanes cannot observe
+        # metadata left by a previous, larger batch.
+        self.input_ids_np[:graph_bucket] = 0
+        self.positions_np[:graph_bucket] = 0
+        self.slot_mapping_np[:graph_bucket] = -1
+        self.context_lens_np[:graph_bucket] = 0
+        for row, seq in enumerate(seqs):
+            sequence_length = len(seq)
+            self.input_ids_np[row] = seq.last_token
+            self.positions_np[row] = sequence_length - 1
+            self.context_lens_np[row] = sequence_length
+            self.slot_mapping_np[row] = (
+                seq.block_table[-1] * self.block_size + seq.last_block_num_tokens - 1
+            )
+            if include_temperatures:
+                self.temperatures_np[row] = seq.temperature
+
+        active_tables = self.block_tables_np[:graph_bucket, :active_block_width]
+        active_tables.fill(-1)
+        for row, seq in enumerate(seqs):
+            active_tables[row, : len(seq.block_table)] = seq.block_table
+
+        view = DecodeBatchView(
+            batch_size=batch_size,
+            graph_bucket=graph_bucket,
+            active_block_width=active_block_width,
+            padding_rows=graph_bucket - batch_size,
+        )
+        self.last_view = view
+        return view
+
+    def copy_temperatures_to_gpu(self, batch_size: int) -> torch.Tensor:
+        if self.temperatures_gpu is None:
+            raise RuntimeError("temperature GPU storage was not allocated")
+        if batch_size < 1 or batch_size > self.max_batch_size:
+            raise ValueError(f"invalid temperature batch size {batch_size}")
+        target = self.temperatures_gpu[:batch_size]
+        target.copy_(self.temperatures_cpu[:batch_size], non_blocking=True)
+        return target

--- a/nanovllm/engine/model_runner.py
+++ b/nanovllm/engine/model_runner.py
@@ -5,6 +5,7 @@ from multiprocessing.synchronize import Event
 from multiprocessing.shared_memory import SharedMemory
 
 from nanovllm.config import Config
+from nanovllm.engine.decode_input_batch import DecodeInputBatch
 from nanovllm.engine.sequence import Sequence
 from nanovllm.models.qwen3 import Qwen3ForCausalLM
 from nanovllm.layers.sampler import Sampler
@@ -170,6 +171,24 @@ class ModelRunner:
         return input_ids, positions
 
     def prepare_decode(self, seqs: list[Sequence]):
+        if (
+            not self.enforce_eager
+            and hasattr(self, "decode_input_batch")
+            and len(seqs) <= 512
+        ):
+            batch_size = len(seqs)
+            graph_bucket = next(x for x in self.graph_bs if x >= batch_size)
+            self.decode_input_batch.prepare_decode(
+                seqs,
+                graph_bucket,
+                include_temperatures=self.rank == 0,
+            )
+            set_context(False)
+            return (
+                self.decode_input_batch.input_ids_cpu[:batch_size],
+                self.decode_input_batch.positions_cpu[:batch_size],
+            )
+
         input_ids = []
         positions = []
         slot_mapping = []
@@ -187,7 +206,14 @@ class ModelRunner:
         set_context(False, slot_mapping=slot_mapping, context_lens=context_lens, block_tables=block_tables)
         return input_ids, positions
 
-    def prepare_sample(self, seqs: list[Sequence]):
+    def prepare_sample(self, seqs: list[Sequence], is_prefill: bool):
+        if (
+            not is_prefill
+            and not self.enforce_eager
+            and hasattr(self, "decode_input_batch")
+            and len(seqs) <= 512
+        ):
+            return self.decode_input_batch.copy_temperatures_to_gpu(len(seqs))
         temperatures = [seq.temperature for seq in seqs]
         temperatures = torch.tensor(temperatures, dtype=torch.float32, pin_memory=True).cuda(non_blocking=True)
         return temperatures
@@ -198,22 +224,46 @@ class ModelRunner:
             return self.model.compute_logits(self.model(input_ids, positions))
         else:
             bs = input_ids.size(0)
-            context = get_context()
-            graph = self.graphs[next(x for x in self.graph_bs if x >= bs)]
+            graph_bucket = next(x for x in self.graph_bs if x >= bs)
+            graph = self.graphs[graph_bucket]
             graph_vars = self.graph_vars
-            graph_vars["input_ids"][:bs] = input_ids
-            graph_vars["positions"][:bs] = positions
-            graph_vars["slot_mapping"].fill_(-1)
-            graph_vars["slot_mapping"][:bs] = context.slot_mapping
-            graph_vars["context_lens"].zero_()
-            graph_vars["context_lens"][:bs] = context.context_lens
-            graph_vars["block_tables"][:bs, :context.block_tables.size(1)] = context.block_tables
+            if input_ids.device.type == "cpu" and hasattr(self, "decode_input_batch"):
+                decode_batch = self.decode_input_batch
+                view = decode_batch.last_view
+                if view is None or view.batch_size != bs or view.graph_bucket != graph_bucket:
+                    raise RuntimeError("CUDA graph decode metadata does not match the active batch")
+                graph_vars["input_ids"][:graph_bucket].copy_(
+                    decode_batch.input_ids_cpu[:graph_bucket], non_blocking=True
+                )
+                graph_vars["positions"][:graph_bucket].copy_(
+                    decode_batch.positions_cpu[:graph_bucket], non_blocking=True
+                )
+                graph_vars["slot_mapping"][:graph_bucket].copy_(
+                    decode_batch.slot_mapping_cpu[:graph_bucket], non_blocking=True
+                )
+                graph_vars["context_lens"][:graph_bucket].copy_(
+                    decode_batch.context_lens_cpu[:graph_bucket], non_blocking=True
+                )
+                active_width = view.active_block_width
+                graph_vars["block_tables"][:graph_bucket, :active_width].copy_(
+                    decode_batch.block_tables_cpu[:graph_bucket, :active_width],
+                    non_blocking=True,
+                )
+            else:
+                context = get_context()
+                graph_vars["input_ids"][:bs] = input_ids
+                graph_vars["positions"][:bs] = positions
+                graph_vars["slot_mapping"].fill_(-1)
+                graph_vars["slot_mapping"][:bs] = context.slot_mapping
+                graph_vars["context_lens"].zero_()
+                graph_vars["context_lens"][:bs] = context.context_lens
+                graph_vars["block_tables"][:bs, :context.block_tables.size(1)] = context.block_tables
             graph.replay()
             return self.model.compute_logits(graph_vars["outputs"][:bs])
 
     def run(self, seqs: list[Sequence], is_prefill: bool) -> list[int]:
         input_ids, positions = self.prepare_prefill(seqs) if is_prefill else self.prepare_decode(seqs)
-        temperatures = self.prepare_sample(seqs) if self.rank == 0 else None
+        temperatures = self.prepare_sample(seqs, is_prefill) if self.rank == 0 else None
         logits = self.run_model(input_ids, positions, is_prefill)
         token_ids = self.sampler(logits, temperatures).tolist() if self.rank == 0 else None
         reset_context()
@@ -255,3 +305,13 @@ class ModelRunner:
             block_tables=block_tables,
             outputs=outputs,
         )
+        # Decode metadata is filled between graph replays, outside inference mode.
+        with torch.inference_mode(False):
+            self.decode_input_batch = DecodeInputBatch(
+                max_bs,
+                max_num_blocks,
+                self.block_size,
+                pin_memory=True,
+                allocate_temperature_gpu=self.rank == 0,
+                device="cuda",
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 description = "a lightweight vLLM implementation built from scratch"
 requires-python = ">=3.10,<3.13"
 dependencies = [
+    "numpy",
     "torch>=2.4.0",
     "triton>=3.0.0",
     "transformers>=4.51.0",

--- a/tests/test_block_manager_boundaries.py
+++ b/tests/test_block_manager_boundaries.py
@@ -1,0 +1,41 @@
+import unittest
+
+from nanovllm.engine.block_manager import BlockManager
+from nanovllm.engine.sequence import Sequence
+
+
+class BlockManagerBoundaryTest(unittest.TestCase):
+    def test_decode_allocates_at_lengths_257_and_513(self):
+        block_size = 256
+        manager = BlockManager(num_blocks=8, block_size=block_size)
+        seq = Sequence(list(range(block_size)))
+        manager.allocate(seq, num_cached_blocks=0)
+        self.assertEqual(len(seq.block_table), 1)
+
+        seq.append_token(1001)
+        self.assertEqual(len(seq), 257)
+        self.assertEqual(seq.last_block_num_tokens, 1)
+        self.assertTrue(manager.can_append(seq))
+        manager.may_append(seq)
+        self.assertEqual(len(seq.block_table), 2)
+        self.assertEqual(
+            seq.block_table[-1] * block_size + seq.last_block_num_tokens - 1,
+            seq.block_table[-1] * block_size,
+        )
+
+        for token_id in range(1002, 1257):
+            seq.append_token(token_id)
+            manager.may_append(seq)
+        self.assertEqual(len(seq), 512)
+        self.assertEqual(len(seq.block_table), 2)
+
+        seq.append_token(1257)
+        self.assertEqual(len(seq), 513)
+        self.assertEqual(seq.last_block_num_tokens, 1)
+        self.assertTrue(manager.can_append(seq))
+        manager.may_append(seq)
+        self.assertEqual(len(seq.block_table), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_decode_input_batch.py
+++ b/tests/test_decode_input_batch.py
@@ -1,0 +1,144 @@
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+
+from nanovllm.engine.decode_input_batch import DecodeInputBatch
+
+
+class FakeSequence:
+    def __init__(self, length, last_token, block_table, block_size=4, temperature=1.0):
+        self.num_tokens = length
+        self.last_token = last_token
+        self.block_table = list(block_table)
+        self.block_size = block_size
+        self.temperature = temperature
+
+    def __len__(self):
+        return self.num_tokens
+
+    @property
+    def last_block_num_tokens(self):
+        return self.num_tokens - ((self.num_tokens - 1) // self.block_size) * self.block_size
+
+
+class DecodeInputBatchTest(unittest.TestCase):
+    def make_batch(self, max_batch_size=16, max_num_blocks=8):
+        return DecodeInputBatch(
+            max_batch_size,
+            max_num_blocks,
+            block_size=4,
+            pin_memory=False,
+            allocate_temperature_gpu=False,
+        )
+
+    def test_vector_metadata_slot_mapping_and_padding(self):
+        batch = self.make_batch()
+        seqs = [
+            FakeSequence(5, 101, [3, 7], temperature=0.5),
+            FakeSequence(8, 102, [4, 9], temperature=0.7),
+            FakeSequence(3, 103, [11], temperature=0.9),
+        ]
+        view = batch.prepare_decode(seqs, graph_bucket=4, include_temperatures=True)
+
+        self.assertEqual(view.active_block_width, 2)
+        self.assertEqual(view.padding_rows, 1)
+        self.assertEqual(batch.input_ids_cpu[:4].tolist(), [101, 102, 103, 0])
+        self.assertEqual(batch.positions_cpu[:4].tolist(), [4, 7, 2, 0])
+        self.assertEqual(batch.context_lens_cpu[:4].tolist(), [5, 8, 3, 0])
+        self.assertEqual(batch.slot_mapping_cpu[:4].tolist(), [28, 39, 46, -1])
+        self.assertEqual(
+            batch.block_tables_cpu[:4, :2].tolist(),
+            [[3, 7], [4, 9], [11, -1], [-1, -1]],
+        )
+        self.assertEqual(
+            batch.temperatures_cpu[:3].tolist(),
+            [np.float32(0.5), np.float32(0.7), np.float32(0.9)],
+        )
+
+    def test_dynamic_batch_and_width_transitions_clear_accessible_state(self):
+        batch = self.make_batch(max_batch_size=16, max_num_blocks=8)
+        transitions = [
+            (1, 1),
+            (8, 4),
+            (3, 2),
+            (16, 3),
+            (1, 1),
+        ]
+        for step, (batch_size, width) in enumerate(transitions):
+            bucket = next(size for size in [1, 2, 4, 8, 16] if size >= batch_size)
+            seqs = [
+                FakeSequence(
+                    width * 4,
+                    1000 + step * 100 + row,
+                    [step * 100 + row * 8 + col for col in range(width)],
+                )
+                for row in range(batch_size)
+            ]
+            view = batch.prepare_decode(seqs, bucket, include_temperatures=False)
+            self.assertEqual(view.active_block_width, width)
+            self.assertTrue(
+                all(value == -1 for value in batch.slot_mapping_cpu[batch_size:bucket].tolist())
+            )
+            self.assertTrue(
+                all(value == 0 for value in batch.context_lens_cpu[batch_size:bucket].tolist())
+            )
+            self.assertTrue(
+                all(
+                    value == -1
+                    for row in batch.block_tables_cpu[batch_size:bucket, :width].tolist()
+                    for value in row
+                )
+            )
+
+    def test_short_rows_are_padded_with_minus_one(self):
+        batch = self.make_batch()
+        seqs = [FakeSequence(12, 1, [1, 2, 3]), FakeSequence(4, 2, [8])]
+        batch.prepare_decode(seqs, graph_bucket=2, include_temperatures=False)
+        self.assertEqual(batch.block_tables_cpu[:2, :3].tolist(), [[1, 2, 3], [8, -1, -1]])
+
+    def test_temperature_is_only_written_when_requested(self):
+        batch = self.make_batch()
+        batch.temperatures_cpu.fill_(-123.0)
+        seq = FakeSequence(4, 1, [2], temperature=0.25)
+
+        view = batch.prepare_decode([seq], 1, include_temperatures=False)
+        self.assertEqual(batch.temperatures_cpu[0].item(), -123.0)
+        view = batch.prepare_decode([seq], 1, include_temperatures=True)
+        self.assertAlmostEqual(batch.temperatures_cpu[0].item(), 0.25)
+
+    def test_numpy_views_share_persistent_tensor_storage(self):
+        batch = self.make_batch()
+        pairs = [
+            (batch.input_ids_cpu, batch.input_ids_np),
+            (batch.positions_cpu, batch.positions_np),
+            (batch.slot_mapping_cpu, batch.slot_mapping_np),
+            (batch.context_lens_cpu, batch.context_lens_np),
+            (batch.block_tables_cpu, batch.block_tables_np),
+            (batch.temperatures_cpu, batch.temperatures_np),
+        ]
+        pointers = [tensor.data_ptr() for tensor, _ in pairs]
+        for tensor, array in pairs:
+            self.assertEqual(tensor.data_ptr(), array.__array_interface__["data"][0])
+
+        batch.prepare_decode([FakeSequence(4, 1, [2])], 1, True)
+        batch.prepare_decode([FakeSequence(8, 2, [3, 4])], 1, True)
+        self.assertEqual(pointers, [tensor.data_ptr() for tensor, _ in pairs])
+
+    def test_rejects_capacity_overflow(self):
+        batch = self.make_batch(max_batch_size=4, max_num_blocks=2)
+        with self.assertRaises(ValueError):
+            batch.prepare_decode([FakeSequence(12, 1, [1, 2, 3])], 1, False)
+
+    def test_steady_state_does_not_call_tensor_allocators(self):
+        batch = self.make_batch()
+        seqs = [FakeSequence(4, 1, [2]), FakeSequence(8, 2, [3, 4])]
+        with (
+            patch("torch.tensor", side_effect=AssertionError("torch.tensor called")),
+            patch("torch.empty", side_effect=AssertionError("torch.empty called")),
+        ):
+            batch.prepare_decode(seqs, graph_bucket=2, include_temperatures=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds a small `DecodeInputBatch` owner for CUDA Graph decode metadata. It allocates pinned CPU tensors once, exposes zero-copy NumPy views for CPU packing, and copies directly into the persistent graph inputs before replay.

The CUDA Graph path now:

- reuses input ID, position, slot mapping, context length, block table, and temperature buffers;
- avoids per-token `torch.tensor(..., pin_memory=True)` allocation;
- avoids the temporary metadata GPU tensors and their second D2D copy;
- copies only `graph_bucket x active_block_width` block-table entries;
- initializes captured padding lanes with `input=0`, `position=0`, `slot=-1`, `context_len=0`, and block table `-1`.

Prefill, eager execution, and batches above the graph limit keep the existing path.

## Why

This follows #175 and builds on the persistent-buffer direction in #176. In an A40/Qwen3-0.6B A/B/C experiment, #176 improved batch 1/4 but regressed at batch 8/16 because per-element PyTorch tensor assignment became CPU-bound. Filling shared NumPy views removes that dispatch cost while retaining the allocation-free design.

Experimental-branch results (three measured runs each):

| workload | main tok/s | #176 tok/s | this design tok/s | vs main |
|---|---:|---:|---:|---:|
| b1, p128/o128 | 251.5 | 261.5 | 266.0 | +5.80% |
| b4, p128/o128 | 934.8 | 946.2 | 977.9 | +4.62% |
| b8, p128/o128 | 1785.5 | 1766.7 | 1856.7 | +3.99% |
| b16, p128/o128 | 3349.7 | 3206.9 | 3465.5 | +3.46% |
| b4, p1024/o128 | 766.8 | 767.8 | 800.0 | +4.33% |

A 24-case, 10,000-iteration CPU packing matrix measured a 43.3% lower geometric-mean median than main and 95.2% lower than the scalar-assignment implementation.

## Correctness and profiling

- 8 CPU unit tests pass, covering metadata values, ragged tables, `1->8->3->16->1` bucket transitions, width contraction/expansion, stable storage addresses, capacity rejection, and absence of steady-state tensor allocator calls.
- Added a block-boundary regression proving allocation at sequence lengths 257 and 513 is correct (`last_block_num_tokens == 1`).
- Experimental-branch token checksums matched main for batch 1/4/8/16, prompt lengths 255/256/511, and dynamic request finish/reuse.
- Nsight on the experimental branch showed zero metadata D2D copies and no steady-state `cudaMalloc`/`cudaHostAlloc`.

## Current draft limitations

- The clean upstream branch still needs a fresh A40 rerun; the table above is from the equivalent core implementation in the instrumented experiment branch.
- Six metadata H2D submissions remain per decode step. Packing them into one transfer is intentionally kept out of this host-only PR.
- Single-GPU synchronous execution is validated. Tensor-parallel buffer lifetime behavior still needs explicit testing.
- This does not include the max-model-length graph shape change from #190/#191.

Related: #175. Builds on and credits #176.