### PR TITLE
fix: validate request token limits

### DIFF
--- a/nanovllm/engine/llm_engine.py
+++ b/nanovllm/engine/llm_engine.py
@@ -18,6 +18,7 @@ class LLMEngine:
         config_fields = {field.name for field in fields(Config)}
         config_kwargs = {k: v for k, v in kwargs.items() if k in config_fields}
         config = Config(model, **config_kwargs)
+        self.max_model_len = config.max_model_len
         Sequence.block_size = config.kvcache_block_size
         self.ps = []
         self.events = []
@@ -43,6 +44,7 @@ class LLMEngine:
     def add_request(self, prompt: str | list[int], sampling_params: SamplingParams):
         if isinstance(prompt, str):
             prompt = self.tokenizer.encode(prompt)
+        sampling_params.validate_request_length(len(prompt), self.max_model_len)
         seq = Sequence(prompt, sampling_params)
         self.scheduler.add(seq)
 

--- a/nanovllm/sampling_params.py
+++ b/nanovllm/sampling_params.py
@@ -9,3 +9,16 @@ class SamplingParams:
 
     def __post_init__(self):
         assert self.temperature > 1e-10, "greedy sampling is not permitted"
+        assert (
+            isinstance(self.max_tokens, int)
+            and not isinstance(self.max_tokens, bool)
+            and self.max_tokens > 0
+        ), "max_tokens must be a positive integer"
+
+    def validate_request_length(self, prompt_length: int, max_model_len: int):
+        requested_tokens = prompt_length + self.max_tokens
+        if requested_tokens > max_model_len:
+            raise ValueError(
+                f"request requires {requested_tokens} tokens, exceeding "
+                f"max_model_len={max_model_len}"
+            )

--- a/nanovllm/sampling_params.py
+++ b/nanovllm/sampling_params.py
@@ -17,6 +17,8 @@ class SamplingParams:
             raise ValueError("max_tokens must be a positive integer")
 
     def validate_request_length(self, prompt_length: int, max_model_len: int):
+        if prompt_length <= 0:
+            raise ValueError("prompt must contain at least one token")
         requested_tokens = prompt_length + self.max_tokens
         if requested_tokens > max_model_len:
             raise ValueError(

--- a/nanovllm/sampling_params.py
+++ b/nanovllm/sampling_params.py
@@ -9,11 +9,12 @@ class SamplingParams:
 
     def __post_init__(self):
         assert self.temperature > 1e-10, "greedy sampling is not permitted"
-        assert (
+        if not (
             isinstance(self.max_tokens, int)
             and not isinstance(self.max_tokens, bool)
             and self.max_tokens > 0
-        ), "max_tokens must be a positive integer"
+        ):
+            raise ValueError("max_tokens must be a positive integer")
 
     def validate_request_length(self, prompt_length: int, max_model_len: int):
         requested_tokens = prompt_length + self.max_tokens

--- a/tests/test_request_validation.py
+++ b/tests/test_request_validation.py
@@ -24,6 +24,11 @@ def test_request_length_rejects_total_over_limit():
         SamplingParams(max_tokens=4).validate_request_length(5, 8)
 
 
+def test_request_length_rejects_empty_prompt():
+    with pytest.raises(ValueError, match="at least one token"):
+        SamplingParams(max_tokens=1).validate_request_length(0, 8)
+
+
 def test_request_length_accepts_total_at_limit():
     SamplingParams(max_tokens=4).validate_request_length(4, 8)
 
@@ -36,3 +41,14 @@ def test_engine_validates_string_prompt_after_tokenization():
 
     with pytest.raises(ValueError, match="4 tokens.*max_model_len=3"):
         engine.add_request("prompt", SamplingParams(max_tokens=1))
+
+
+@pytest.mark.parametrize("prompt", [[], ""])
+def test_engine_rejects_empty_tokenized_prompt(prompt):
+    engine = object.__new__(LLMEngine)
+    engine.max_model_len = 8
+    engine.tokenizer = SimpleNamespace(encode=lambda _: [])
+    engine.scheduler = SimpleNamespace(add=lambda _: pytest.fail("scheduled"))
+
+    with pytest.raises(ValueError, match="at least one token"):
+        engine.add_request(prompt, SamplingParams(max_tokens=1))

--- a/tests/test_request_validation.py
+++ b/tests/test_request_validation.py
@@ -1,0 +1,38 @@
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+flash_attn = types.ModuleType("flash_attn")
+flash_attn.flash_attn_varlen_func = object
+flash_attn.flash_attn_with_kvcache = object
+sys.modules.setdefault("flash_attn", flash_attn)
+
+from nanovllm.sampling_params import SamplingParams
+from nanovllm.engine.llm_engine import LLMEngine
+
+
+@pytest.mark.parametrize("max_tokens", [0, -1, 1.5, True])
+def test_sampling_params_reject_invalid_max_tokens(max_tokens):
+    with pytest.raises(AssertionError, match="positive integer"):
+        SamplingParams(max_tokens=max_tokens)
+
+
+def test_request_length_rejects_total_over_limit():
+    with pytest.raises(ValueError, match="9 tokens.*max_model_len=8"):
+        SamplingParams(max_tokens=4).validate_request_length(5, 8)
+
+
+def test_request_length_accepts_total_at_limit():
+    SamplingParams(max_tokens=4).validate_request_length(4, 8)
+
+
+def test_engine_validates_string_prompt_after_tokenization():
+    engine = object.__new__(LLMEngine)
+    engine.max_model_len = 3
+    engine.tokenizer = SimpleNamespace(encode=lambda _: [1, 2, 3])
+    engine.scheduler = SimpleNamespace(add=lambda _: pytest.fail("scheduled"))
+
+    with pytest.raises(ValueError, match="4 tokens.*max_model_len=3"):
+        engine.add_request("prompt", SamplingParams(max_tokens=1))

--- a/tests/test_request_validation.py
+++ b/tests/test_request_validation.py
@@ -15,7 +15,7 @@ from nanovllm.engine.llm_engine import LLMEngine
 
 @pytest.mark.parametrize("max_tokens", [0, -1, 1.5, True])
 def test_sampling_params_reject_invalid_max_tokens(max_tokens):
-    with pytest.raises(AssertionError, match="positive integer"):
+    with pytest.raises(ValueError, match="positive integer"):
         SamplingParams(max_tokens=max_tokens)
 
 


### PR DESCRIPTION
## Summary

- reject non-positive or non-integer `max_tokens` values that can otherwise generate indefinitely
- reject empty prompts before they reach sequence construction
- reject requests whose prompt plus requested completion exceeds `max_model_len`
- validate string prompts after tokenization
- cover invalid, empty, exact-boundary, and string-prompt admission with CPU-only regression tests

## Why

The scheduler finishes a request when its integer completion count reaches `max_tokens`. Values such as `0`, negative numbers, or fractional values can never be reached after the first generated token. Empty prompts currently fail later with an unclear `IndexError` during sequence construction. Separately, request admission allows prompt plus completion length to exceed the configured context capacity.

The engine sizes its KV cache and CUDA Graph block tables from `max_model_len`. Enforcing these conditions at request admission keeps sequence construction, eager execution, KV-cache sizing, and CUDA Graph replay within explicit invariants and gives callers actionable `ValueError` messages.

## Relationship to #191

#191 defensively falls back from CUDA Graph replay when runtime graph buffers do not fit. This patch enforces the separate request-admission invariant, so the changes are complementary.

## Verification

- `10 passed` in the focused CPU-only regression suite
- the same `10 passed` under Python `-O`
- Python `compileall` passed
- `git diff --check` passed

No GPU performance claim is made.
