### PR TITLE
fix(loader): reject incomplete safetensors checkpoints

### DIFF
--- a/nanovllm/utils/loader.py
+++ b/nanovllm/utils/loader.py
@@ -1,5 +1,6 @@
 import os
 from glob import glob
+import json
 import torch
 from torch import nn
 from safetensors import safe_open
@@ -11,7 +12,20 @@ def default_weight_loader(param: nn.Parameter, loaded_weight: torch.Tensor):
 
 def load_model(model: nn.Module, path: str):
     packed_modules_mapping = getattr(model, "packed_modules_mapping", {})
-    for file in glob(os.path.join(path, "*.safetensors")):
+    files = sorted(glob(os.path.join(path, "*.safetensors")))
+    if not files:
+        raise FileNotFoundError(f"no safetensors files found in model path: {path}")
+    available = {os.path.basename(file) for file in files}
+    for index_file in glob(os.path.join(path, "*.safetensors.index.json")):
+        with open(index_file, encoding="utf-8") as stream:
+            index = json.load(stream)
+        missing = sorted(set(index["weight_map"].values()) - available)
+        if missing:
+            raise FileNotFoundError(
+                f"missing safetensors shards referenced by {index_file}: "
+                + ", ".join(missing)
+            )
+    for file in files:
         with safe_open(file, "pt", "cpu") as f:
             for weight_name in f.keys():
                 for k in packed_modules_mapping:

--- a/tests/test_loader_checkpoint_files.py
+++ b/tests/test_loader_checkpoint_files.py
@@ -1,0 +1,74 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import json
+from tempfile import TemporaryDirectory
+from unittest import TestCase, main
+
+from torch import nn
+import torch
+from safetensors.torch import save_file
+
+
+ROOT = Path(__file__).parents[1]
+SPEC = spec_from_file_location(
+    "loader_checkpoint_files",
+    ROOT / "nanovllm" / "utils" / "loader.py",
+)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError("could not load checkpoint loader")
+LOADER = module_from_spec(SPEC)
+SPEC.loader.exec_module(LOADER)
+
+
+def write_sharded_checkpoint(root: Path, *, complete: bool) -> None:
+    names = [f"model-{index:05d}-of-00002.safetensors" for index in (1, 2)]
+    tensors = (
+        {"0.weight": torch.ones(2, 2)},
+        {"1.weight": torch.full((2, 2), 2.0)},
+    )
+    save_file(tensors[0], root / names[0])
+    if complete:
+        save_file(tensors[1], root / names[1])
+    weight_map = {
+        weight: names[index]
+        for index, shard in enumerate(tensors)
+        for weight in shard
+    }
+    (root / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {}, "weight_map": weight_map})
+    )
+
+
+class LoaderCheckpointFilesTest(TestCase):
+    def test_empty_model_directory_is_rejected(self):
+        with TemporaryDirectory() as directory, self.assertRaisesRegex(
+            FileNotFoundError, "no safetensors files found"
+        ):
+            LOADER.load_model(nn.Linear(2, 2, bias=False), directory)
+
+    def test_missing_indexed_shard_is_rejected_before_partial_loading(self):
+        with TemporaryDirectory() as directory:
+            write_sharded_checkpoint(Path(directory), complete=False)
+            model = nn.Sequential(
+                *(nn.Linear(2, 2, bias=False) for _ in range(2))
+            )
+            untouched = model[0].weight.detach().clone()
+            with self.assertRaisesRegex(
+                FileNotFoundError, "model-00002-of-00002.safetensors"
+            ):
+                LOADER.load_model(model, directory)
+            torch.testing.assert_close(model[0].weight, untouched)
+
+    def test_complete_indexed_checkpoint_loads_all_shards(self):
+        with TemporaryDirectory() as directory:
+            write_sharded_checkpoint(Path(directory), complete=True)
+            model = nn.Sequential(
+                *(nn.Linear(2, 2, bias=False) for _ in range(2))
+            )
+            LOADER.load_model(model, directory)
+            torch.testing.assert_close(model[0].weight, torch.ones(2, 2))
+            torch.testing.assert_close(model[1].weight, torch.full((2, 2), 2.0))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

`load_model` silently succeeds when a model directory contains no Safetensors files. For an indexed checkpoint, it can also begin mutating model parameters before discovering that a referenced shard is absent. The remaining parameters then keep uninitialized `torch.empty` storage.

## Fix

Before opening any shard:

- reject an empty model directory;
- read any `*.safetensors.index.json` files;
- verify that every shard referenced by `weight_map` exists locally.

The normal loading path is unchanged after this preflight.

## Verification

- empty model directory is rejected;
- a missing indexed shard is rejected before any parameter is mutated;
- a complete two-shard checkpoint still loads successfully;
- focused pytest: `3 passed`;
- focused pytest under `python -O`: `3 passed`;
- `compileall` and `git diff --check` passed.
