### PR TITLE
fix(model_runner): gloo/USE_LIBUV fallback so startup works on Windows (#261)

### DIFF
--- a/nanovllm/engine/model_runner.py
+++ b/nanovllm/engine/model_runner.py
@@ -1,3 +1,4 @@
+import os
 import pickle
 import torch
 import torch.distributed as dist
@@ -23,7 +24,14 @@ class ModelRunner:
         self.rank = rank
         self.event = event
 
-        dist.init_process_group("nccl", "tcp://localhost:2333", world_size=self.world_size, rank=rank)
+        if os.name == "nt":
+            # Windows builds of PyTorch ship without libuv; fall back to the
+            # legacy TCPStore so rendezvous does not abort at startup.
+            os.environ.setdefault("USE_LIBUV", "0")
+        # NCCL is only bundled with PyTorch on Linux. On other platforms (or
+        # single-GPU runs, where no cross-GPU collective is issued) gloo works.
+        backend = "nccl" if dist.is_nccl_available() else "gloo"
+        dist.init_process_group(backend, "tcp://localhost:2333", world_size=self.world_size, rank=rank)
         torch.cuda.set_device(rank)
         default_dtype = torch.get_default_dtype()
         torch.set_default_dtype(hf_config.dtype)


### PR DESCRIPTION
## Problem

On Windows the engine crashes during `ModelRunner.__init__`, before any model is loaded, even with a single GPU and default settings (fixes #261). Two platform gaps in `model_runner.py`:

1. `dist.init_process_group("nccl", ...)` — NCCL is only bundled with PyTorch on Linux, so this raises `RuntimeError: Distributed package doesn't have NCCL built in` on Windows.
2. PyTorch's rendezvous defaults to a libuv `TCPStore`, but Windows wheels are frequently built without libuv, raising `RuntimeError: use_libuv was requested but PyTorch was build without libuv support`.

Since single-GPU runs never issue a cross-GPU collective (the `dist.barrier()` calls are all guarded by `world_size > 1`), gloo is a correct backend there.

## Fix

Two small changes at the process-group init, both no-ops on Linux:

- Pick `nccl` only when `dist.is_nccl_available()`, else fall back to `gloo`.
- On Windows, `os.environ.setdefault("USE_LIBUV", "0")` so rendezvous uses the legacy TCPStore.

Multi-GPU tensor parallelism still requires NCCL (i.e. Linux); this only unblocks the single-GPU Windows path the issue describes.

## Verification

Reproduced natively on Windows 11 + RTX 4090, `torch 2.5.1+cu121` (`dist.is_nccl_available() == False`), isolated process-group inits:

| init | result |
|---|---|
| `init_process_group("nccl", ...)` | `RuntimeError` (libuv / NCCL) |
| `gloo`, default libuv | `RuntimeError: use_libuv was requested but PyTorch was build without libuv support` |
| **`gloo` + `USE_LIBUV=0` (this fix)** | **OK** |

(On a Windows build that *does* ship libuv, the first failure is instead the NCCL error — the `is_nccl_available()` gate covers that case, so the two changes together handle both build variants.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
