### PR TITLE
fix: validate request token limits

### DIFF
--- a/nanovllm/engine/llm_engine.py
+++ b/nanovllm/engine/llm_engine.py
@@ -18,6 +18,7 @@ class LLMEngine:
         config_fields = {field.name for field in fields(Config)}
         config_kwargs = {k: v for k, v in kwargs.items() if k in config_fields}
         config = Config(model, **config_kwargs)
+        self.max_model_len = config.max_model_len
         Sequence.block_size = config.kvcache_block_size
         self.ps = []
         self.events = []
@@ -43,6 +44,7 @@ class LLMEngine:
     def add_request(self, prompt: str | list[int], sampling_params: SamplingParams):
         if isinstance(prompt, str):
             prompt = self.tokenizer.encode(prompt)
+        sampling_params.validate_request_length(len(prompt), self.max_model_len)
         seq = Sequence(prompt, sampling_params)
         self.scheduler.add(seq)
 

--- a/nanovllm/sampling_params.py
+++ b/nanovllm/sampling_params.py
@@ -9,3 +9,19 @@ class SamplingParams:
 
     def __post_init__(self):
         assert self.temperature > 1e-10, "greedy sampling is not permitted"
+        if not (
+            isinstance(self.max_tokens, int)
+            and not isinstance(self.max_tokens, bool)
+            and self.max_tokens > 0
+        ):
+            raise ValueError("max_tokens must be a positive integer")
+
+    def validate_request_length(self, prompt_length: int, max_model_len: int):
+        if prompt_length <= 0:
+            raise ValueError("prompt must contain at least one token")
+        requested_tokens = prompt_length + self.max_tokens
+        if requested_tokens > max_model_len:
+            raise ValueError(
+                f"request requires {requested_tokens} tokens, exceeding "
+                f"max_model_len={max_model_len}"
+            )

--- a/tests/test_request_validation.py
+++ b/tests/test_request_validation.py
@@ -1,0 +1,99 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+def load_request_types():
+    root = Path(__file__).parents[1]
+    package = types.ModuleType("nanovllm")
+    package.__path__ = [str(root / "nanovllm")]
+    engine_package = types.ModuleType("nanovllm.engine")
+    engine_package.__path__ = [str(root / "nanovllm" / "engine")]
+
+    sampling_spec = spec_from_file_location(
+        "nanovllm.sampling_params", root / "nanovllm" / "sampling_params.py"
+    )
+    if sampling_spec is None or sampling_spec.loader is None:
+        raise RuntimeError("could not load sampling parameters")
+    sampling_module = module_from_spec(sampling_spec)
+    sampling_spec.loader.exec_module(sampling_module)
+
+    config = types.ModuleType("nanovllm.config")
+    config.Config = object
+    sequence = types.ModuleType("nanovllm.engine.sequence")
+    sequence.Sequence = object
+    scheduler = types.ModuleType("nanovllm.engine.scheduler")
+    scheduler.Scheduler = object
+    model_runner = types.ModuleType("nanovllm.engine.model_runner")
+    model_runner.ModelRunner = object
+
+    engine_spec = spec_from_file_location(
+        "nanovllm.engine.llm_engine",
+        root / "nanovllm" / "engine" / "llm_engine.py",
+    )
+    if engine_spec is None or engine_spec.loader is None:
+        raise RuntimeError("could not load LLM engine")
+    engine_module = module_from_spec(engine_spec)
+    with patch.dict(
+        sys.modules,
+        {
+            "nanovllm": package,
+            "nanovllm.config": config,
+            "nanovllm.sampling_params": sampling_module,
+            "nanovllm.engine": engine_package,
+            "nanovllm.engine.sequence": sequence,
+            "nanovllm.engine.scheduler": scheduler,
+            "nanovllm.engine.model_runner": model_runner,
+        },
+    ):
+        engine_spec.loader.exec_module(engine_module)
+    return sampling_module.SamplingParams, engine_module.LLMEngine
+
+
+SamplingParams, LLMEngine = load_request_types()
+
+
+@pytest.mark.parametrize("max_tokens", [0, -1, 1.5, True])
+def test_sampling_params_reject_invalid_max_tokens(max_tokens):
+    with pytest.raises(ValueError, match="positive integer"):
+        SamplingParams(max_tokens=max_tokens)
+
+
+def test_request_length_rejects_total_over_limit():
+    with pytest.raises(ValueError, match="9 tokens.*max_model_len=8"):
+        SamplingParams(max_tokens=4).validate_request_length(5, 8)
+
+
+def test_request_length_rejects_empty_prompt():
+    with pytest.raises(ValueError, match="at least one token"):
+        SamplingParams(max_tokens=1).validate_request_length(0, 8)
+
+
+def test_request_length_accepts_total_at_limit():
+    SamplingParams(max_tokens=4).validate_request_length(4, 8)
+
+
+def test_engine_validates_string_prompt_after_tokenization():
+    engine = object.__new__(LLMEngine)
+    engine.max_model_len = 3
+    engine.tokenizer = SimpleNamespace(encode=lambda _: [1, 2, 3])
+    engine.scheduler = SimpleNamespace(add=lambda _: pytest.fail("scheduled"))
+
+    with pytest.raises(ValueError, match="4 tokens.*max_model_len=3"):
+        engine.add_request("prompt", SamplingParams(max_tokens=1))
+
+
+@pytest.mark.parametrize("prompt", [[], ""])
+def test_engine_rejects_empty_tokenized_prompt(prompt):
+    engine = object.__new__(LLMEngine)
+    engine.max_model_len = 8
+    engine.tokenizer = SimpleNamespace(encode=lambda _: [])
+    engine.scheduler = SimpleNamespace(add=lambda _: pytest.fail("scheduled"))
+
+    with pytest.raises(ValueError, match="at least one token"):
+        engine.add_request(prompt, SamplingParams(max_tokens=1))


### PR DESCRIPTION
## Summary

- reject non-positive or non-integer `max_tokens` values that can otherwise generate indefinitely
- reject empty prompts before they reach sequence construction
- reject requests whose prompt plus requested completion exceeds `max_model_len`
- validate string prompts after tokenization
- cover invalid, empty, exact-boundary, and string-prompt admission with CPU-only regression tests

## Why

The scheduler finishes a request when its integer completion count reaches `max_tokens`. Values such as `0`, negative numbers, or fractional values can never be reached after the first generated token. Empty prompts currently fail later with an unclear `IndexError` during sequence construction. Separately, request admission allows prompt plus completion length to exceed the configured context capacity.

The engine sizes its KV cache and CUDA Graph block tables from `max_model_len`. Enforcing these conditions at request admission keeps sequence construction, eager execution, KV-cache sizing, and CUDA Graph replay within explicit invariants and gives callers actionable `ValueError` messages.

## Verification

- focused CPU-only regression suite: `10 passed`
- the same suite under Python `-O`: `10 passed`
- complete available upstream suite: `10 passed`
- repository policy, `compileall`, and `git diff --check` passed

No GPU performance claim is made.

