### PR TITLE
fix(scheduler): enforce max_num_seqs across active requests

### DIFF
--- a/nanovllm/engine/scheduler.py
+++ b/nanovllm/engine/scheduler.py
@@ -25,9 +25,13 @@ class Scheduler:
     def schedule(self) -> tuple[list[Sequence], bool]:
         scheduled_seqs = []
         num_batched_tokens = 0
+        num_running = len(self.running)
 
         # prefill
-        while self.waiting and len(scheduled_seqs) < self.max_num_seqs:
+        while (
+            self.waiting
+            and num_running + len(scheduled_seqs) < self.max_num_seqs
+        ):
             seq = self.waiting[0]
             remaining = self.max_num_batched_tokens - num_batched_tokens
             if remaining == 0:

--- a/tests/test_scheduler_sequence_limit.py
+++ b/tests/test_scheduler_sequence_limit.py
@@ -1,0 +1,101 @@
+from collections import deque
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+
+def load_scheduler():
+    config = ModuleType("nanovllm.config")
+    config.Config = object
+    sequence = ModuleType("nanovllm.engine.sequence")
+    sequence.Sequence = object
+    sequence.SequenceStatus = SimpleNamespace(RUNNING=object())
+    block_manager = ModuleType("nanovllm.engine.block_manager")
+    block_manager.BlockManager = object
+    with patch.dict(sys.modules, {
+        "nanovllm.config": config,
+        "nanovllm.engine.sequence": sequence,
+        "nanovllm.engine.block_manager": block_manager,
+    }):
+        path = Path(__file__).parents[1] / "nanovllm/engine/scheduler.py"
+        spec = spec_from_file_location("scheduler_sequence_limit", path)
+        if spec is None or spec.loader is None:
+            raise RuntimeError("could not load scheduler module")
+        module = module_from_spec(spec)
+        spec.loader.exec_module(module)
+    return module.Scheduler
+
+
+Scheduler = load_scheduler()
+
+
+def make_sequence(seq_id, *, running=False):
+    return SimpleNamespace(
+        seq_id=seq_id,
+        block_table=[] if not running else [0],
+        num_tokens=4,
+        num_cached_tokens=4 if running else 0,
+        num_scheduled_tokens=0,
+        is_prefill=not running,
+        status=None,
+    )
+
+
+def make_scheduler(*, running=(), waiting=(), max_num_batched_tokens=64):
+    scheduler = object.__new__(Scheduler)
+    scheduler.max_num_seqs = 2
+    scheduler.max_num_batched_tokens = max_num_batched_tokens
+    scheduler.block_size = 4
+    scheduler.running = deque(running)
+    scheduler.waiting = deque(waiting)
+    scheduler.block_manager = Mock()
+    scheduler.block_manager.can_allocate.return_value = 0
+    scheduler.block_manager.can_append.return_value = True
+    return scheduler
+
+
+class SchedulerSequenceLimitTest(TestCase):
+    def test_running_sequences_count_toward_limit(self):
+        running = [make_sequence(1, running=True), make_sequence(2, running=True)]
+        waiting = make_sequence(3)
+        scheduler = make_scheduler(running=running, waiting=[waiting])
+
+        scheduled, is_prefill = scheduler.schedule()
+
+        self.assertFalse(is_prefill)
+        self.assertEqual(scheduled, running)
+        self.assertEqual(list(scheduler.waiting), [waiting])
+        scheduler.block_manager.can_allocate.assert_not_called()
+
+    def test_waiting_sequence_uses_remaining_slot(self):
+        running = make_sequence(1, running=True)
+        waiting = make_sequence(2)
+        scheduler = make_scheduler(running=[running], waiting=[waiting])
+
+        scheduled, is_prefill = scheduler.schedule()
+
+        self.assertTrue(is_prefill)
+        self.assertEqual(scheduled, [waiting])
+        self.assertEqual(list(scheduler.running), [running, waiting])
+        self.assertFalse(scheduler.waiting)
+
+    def test_chunked_prefill_consumes_the_remaining_sequence_slot(self):
+        running = make_sequence(1, running=True)
+        first = make_sequence(2)
+        second = make_sequence(3)
+        scheduler = make_scheduler(
+            running=[running],
+            waiting=[first, second],
+            max_num_batched_tokens=2,
+        )
+
+        scheduled, is_prefill = scheduler.schedule()
+
+        self.assertTrue(is_prefill)
+        self.assertEqual(scheduled, [first])
+        self.assertEqual(first.num_scheduled_tokens, 2)
+        self.assertEqual(list(scheduler.waiting), [first, second])
+        self.assertEqual(list(scheduler.running), [running])


### PR DESCRIPTION
## Problem

The prefill admission loop limits only requests selected in the current scheduling step. It does not count requests already in `running`, so a waiting request can be admitted even when all `max_num_seqs` slots are occupied.

Decode repeatedly selects and restores the first `max_num_seqs` requests. An extra resident request at the tail can therefore remain active but starve indefinitely.

## Fix

Snapshot the number of existing running requests before prefill admission and include it in the sequence-capacity condition. Using a snapshot avoids double-counting a chunked prefill that is appended to `running` during the same loop.

## Verification

Focused regressions cover:

- a full active set rejecting another prefill;
- one remaining slot being fully utilized;
- a chunked prefill consuming exactly that remaining slot.

Results:

- focused and complete available pytest suite: `3 passed`;
- the same suite under Python `-O`: `3 passed`;
- repository policy, `compileall`, and `git diff --check` passed.

This changes admission accounting only and adds no extra traversal or allocation.
